### PR TITLE
Fix: User login is not happening if Board is not present in custom field

### DIFF
--- a/apps/admin-app-repo/src/pages/login.tsx
+++ b/apps/admin-app-repo/src/pages/login.tsx
@@ -185,10 +185,13 @@ const LoginPage = () => {
         if (typeof window !== 'undefined' && window.localStorage) {
           if (userInfo) {
             if (userInfo?.customFields) {
-              const boardValues = userInfo.customFields
-                .filter((field: any) => field.label === 'BOARD')
-                .flatMap((field: any) => field.value.split(','))
-                .map((board: string) => board.trim());
+              const boardFields = userInfo.customFields.filter(
+                (field: any) => field.label === 'BOARD'
+              );
+
+              const boardValues = boardFields.length > 0
+                ? boardFields.flatMap((field: any) => field.value.split(',')).map((board: string) => board.trim())
+                : [];
 
               // Check if boardValues is not empty
               if (boardValues.length > 0) {


### PR DESCRIPTION
Allowing the user to login even if board is not present

![image](https://github.com/user-attachments/assets/01dec40b-0c62-496d-bbf5-11514be915e8)

