### PR TITLE
fix:YouthNet bugs resolve

### DIFF
--- a/apps/learner-web-app/src/assets/theme/MuiThemeProvider.tsx
+++ b/apps/learner-web-app/src/assets/theme/MuiThemeProvider.tsx
@@ -256,6 +256,9 @@ export const theme = createTheme({
             '& .MuiButton-startIcon': {
               marginRight: 0,
             },
+            '& span': {
+              color: '#987100',
+            },
           },
         },
       ],

--- a/apps/learner-web-app/src/components/Content/Player.tsx
+++ b/apps/learner-web-app/src/components/Content/Player.tsx
@@ -45,15 +45,15 @@ const App = (props: { userIdLocalstorageName?: string }) => {
             suffix: activeLink ? `?activeLink=${activeLink}` : '',
           },
         ]);
-        setBreadCrumbs(breadcrum);
+        setBreadCrumbs(breadcrum?.slice(0, -1));
       } else {
-        const breadcrum = findCourseUnitPath(
-          response,
-          identifier as string,
-          ['name', 'identifier', 'mimeType'],
-          [{ name: 'Content' }]
-        );
-        setBreadCrumbs(breadcrum);
+        // const breadcrum = findCourseUnitPath(
+        //   response,
+        //   identifier as string,
+        //   ['name', 'identifier', 'mimeType'],
+        //   [{ name: 'Content' }]
+        // );
+        setBreadCrumbs([{ name: 'Content' }]);
       }
     };
     fetch();
@@ -100,7 +100,7 @@ const App = (props: { userIdLocalstorageName?: string }) => {
           >
             <ArrowBackIcon />
           </IconButton>
-          <BreadCrumb breadCrumbs={breadCrumbs} />
+          <BreadCrumb breadCrumbs={breadCrumbs} isShowLastLink />
         </Box>
         <Box
           sx={{

--- a/libs/shared-lib-v2/src/lib/Filter/FilterForm.tsx
+++ b/libs/shared-lib-v2/src/lib/Filter/FilterForm.tsx
@@ -44,8 +44,8 @@ interface FilterSectionProps {
   fields: any[];
   selectedValues: Record<string, any[]>;
   onChange: (code: string, next: any[]) => void;
-  showMore: boolean;
-  setShowMore: (b: boolean) => void;
+  showMore: string[];
+  setShowMore: any;
   repleaseCode?: string;
   staticFormData?: Record<string, object>;
   isShowStaticFilterValue?: boolean;
@@ -76,7 +76,7 @@ export function FilterForm({
   const [renderForm, setRenderForm] = useState<(Category | StaticField)[]>([]);
   const [formData, setFormData] = useState<Record<string, TermOption[]>>({});
   const [loading, setLoading] = useState(true);
-  const [showMore, setShowMore] = useState(false);
+  const [showMore, setShowMore] = useState([]);
 
   const fetchData = useCallback(
     async (noFilter = true) => {
@@ -309,7 +309,9 @@ const FilterSection: React.FC<FilterSectionProps> = ({
         const values = field.options ?? field.range ?? [];
         const code = field.code;
         const selected = selectedValues[code] ?? [];
-        const optionsToShow = showMore ? values : values.slice(0, 3);
+        const optionsToShow = showMore.includes(code)
+          ? values
+          : values.slice(0, 3);
         const staticValues = Array.isArray(staticFormData?.[code])
           ? staticFormData[code]
           : [];
@@ -375,7 +377,7 @@ const FilterSection: React.FC<FilterSectionProps> = ({
                   sx={{ fontWeight: '500', color: '#181D27' }}
                 >
                   <SpeakableText>
-                    {field.name === 'Sub Domain' ? '' : field.name}
+                    {field.name === 'Sub Domain' ? 'Category' : field.name}
                     {/* {field?.options && field?.options?.length} */}
                   </SpeakableText>
                 </Typography>
@@ -429,10 +431,16 @@ const FilterSection: React.FC<FilterSectionProps> = ({
                   <Button
                     variant="text"
                     size="small"
-                    onClick={() => setShowMore(!showMore)}
+                    onClick={() =>
+                      setShowMore((prev: string[]) =>
+                        prev.includes(code)
+                          ? prev.filter((c) => c !== code)
+                          : [...prev, code]
+                      )
+                    }
                     sx={{ mt: 0 }}
                   >
-                    {showMore ? 'Show less ▲' : 'Show more ▼'}
+                    {showMore.includes(code) ? 'Show less ▲' : 'Show more ▼'}
                   </Button>
                 )}
               </AccordionDetails>

--- a/mfes/content/src/components/BreadCrumb.tsx
+++ b/mfes/content/src/components/BreadCrumb.tsx
@@ -5,21 +5,24 @@ import SpeakableText from '@shared-lib-v2/lib/textToSpeech/SpeakableText';
 const BreadCrumb = ({
   breadCrumbs,
   topic,
+  isShowLastLink,
 }: {
   breadCrumbs: any;
   topic?: string;
+  isShowLastLink?: boolean;
 }) => {
   const theme = useTheme();
 
   return (
     <Breadcrumbs separator="›" aria-label="breadcrumb">
       {breadCrumbs?.map((breadcrumb: any, index: number) =>
-        breadcrumb?.link && index !== breadCrumbs.length - 1 ? (
+        breadcrumb?.link &&
+        (index !== breadCrumbs.length - 1 || isShowLastLink) ? (
           <Button
             key={`${breadcrumb?.name ?? breadcrumb?.label ?? ''} ${index}`}
             variant="text"
             sx={{
-              color: theme.palette.primary.main,
+              color: theme.palette.secondary.main,
             }}
             href={breadcrumb?.link}
             rel="noopener noreferrer"

--- a/mfes/content/src/components/BreadCrumb.tsx
+++ b/mfes/content/src/components/BreadCrumb.tsx
@@ -1,6 +1,13 @@
 import React, { memo } from 'react';
-import { Breadcrumbs, Button, Typography, useTheme } from '@mui/material';
+import {
+  Breadcrumbs,
+  Button,
+  Typography,
+  useTheme,
+  useMediaQuery,
+} from '@mui/material';
 import SpeakableText from '@shared-lib-v2/lib/textToSpeech/SpeakableText';
+import { useRouter } from 'next/navigation';
 
 const BreadCrumb = ({
   breadCrumbs,
@@ -12,37 +19,45 @@ const BreadCrumb = ({
   isShowLastLink?: boolean;
 }) => {
   const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const router = useRouter();
+  const handleClick = (link: string) => {
+    router.replace(link);
+  };
 
   return (
     <Breadcrumbs separator="›" aria-label="breadcrumb">
-      {breadCrumbs?.map((breadcrumb: any, index: number) =>
-        breadcrumb?.link &&
-        (index !== breadCrumbs.length - 1 || isShowLastLink) ? (
-          <Button
-            key={`${breadcrumb?.name ?? breadcrumb?.label ?? ''} ${index}`}
-            variant="text"
-            sx={{
-              color: theme.palette.secondary.main,
-            }}
-            href={breadcrumb?.link}
-            rel="noopener noreferrer"
-          >
-            <SpeakableText>
-              {breadcrumb?.name ?? breadcrumb?.label ?? ''}
-            </SpeakableText>
-          </Button>
-        ) : (
-          <Typography
-            key={`${breadcrumb?.name ?? breadcrumb?.label ?? ''} ${index}`}
-            variant="body1"
-            color="text.secondary"
-          >
-            <SpeakableText>
-              {breadcrumb?.name ?? breadcrumb?.label ?? ''}
-            </SpeakableText>
-          </Typography>
-        )
-      )}
+      {breadCrumbs?.map((breadcrumb: any, index: number) => {
+        return breadcrumb?.link &&
+          (index !== breadCrumbs.length - 1 || isShowLastLink)
+          ? ((isMobile &&
+              index === breadCrumbs.length - (isShowLastLink ? 1 : 2)) ||
+              !isMobile) && (
+              <Button
+                key={`${breadcrumb?.name ?? breadcrumb?.label ?? ''} ${index}`}
+                variant="text"
+                sx={{
+                  color: theme.palette.secondary.main,
+                }}
+                onClick={() => handleClick(breadcrumb?.link)}
+              >
+                <SpeakableText>
+                  {breadcrumb?.name ?? breadcrumb?.label ?? ''}
+                </SpeakableText>
+              </Button>
+            )
+          : !isMobile && (
+              <Typography
+                key={`${breadcrumb?.name ?? breadcrumb?.label ?? ''} ${index}`}
+                variant="body1"
+                color="text.secondary"
+              >
+                <SpeakableText>
+                  {breadcrumb?.name ?? breadcrumb?.label ?? ''}
+                </SpeakableText>
+              </Typography>
+            );
+      })}
       {(!breadCrumbs || breadCrumbs?.length === 0) &&
         ['Course', ...(topic ? [topic] : [])].map((key) => (
           <Typography key={key} variant="body1">

--- a/mfes/content/src/components/Card/ContentCard.tsx
+++ b/mfes/content/src/components/Card/ContentCard.tsx
@@ -29,7 +29,7 @@ const ContentCard = ({
             ? item?.posterImage
             : default_img ?? `${AppConst.BASEPATH}/assests/images/image_ver.png`
         }
-        content={item?.description ? item?.description : ''}
+        content={item?.description ? item?.description : ' '}
         actions={
           type !== 'Course' && (
             <StatusIcon
@@ -54,7 +54,10 @@ const ContentCard = ({
         TrackData={trackData}
         type={type}
         onClick={() => handleCardClick(item)}
-        _card={_card}
+        _card={{
+          _contentText: { sx: { height: '120px' } },
+          ..._card,
+        }}
       />
     </CardWrap>
   );

--- a/mfes/content/src/components/Card/InfoCard.tsx
+++ b/mfes/content/src/components/Card/InfoCard.tsx
@@ -5,7 +5,6 @@ import {
   Box,
   IconButton,
   Button,
-  useTheme,
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import React, { useState } from 'react';
@@ -31,7 +30,7 @@ const InfoCard: React.FC<InfoCardProps> = ({
   const { t } = useTranslation();
   const { _infoCard } = _config || {};
   const [openModal, setOpenModal] = useState(false);
-  const theme = useTheme();
+
   return (
     <>
       <Card
@@ -50,7 +49,7 @@ const InfoCard: React.FC<InfoCardProps> = ({
             // objectFit: 'contain',
             ..._infoCard?._cardMedia,
           }}
-          image={item?.appIcon || _infoCard?.default_img}
+          image={item?.posterImage || _infoCard?.default_img}
           alt={item?.name}
         />
         <Box

--- a/mfes/content/src/components/Card/UnitCard.tsx
+++ b/mfes/content/src/components/Card/UnitCard.tsx
@@ -70,15 +70,16 @@ const UnitCard = ({
               : default_img ??
                 `${AppConst.BASEPATH}/assests/images/image_ver.png`
           }
-          content={
-            item?.description ? item?.description : 'No description available'
-          }
+          content={item?.description ? item?.description : ''}
           orientation="horizontal"
           item={item}
           TrackData={trackData}
           type={type}
           onClick={() => handleCardClick(item)}
-          _card={_card}
+          _card={{
+            _contentText: { sx: { height: '120px' } },
+            ..._card,
+          }}
         />
       </Box>
     </Box>


### PR DESCRIPTION
* Duplicate name of content while playing the content through unit
* card height issue when there is no description available
* Currently, for course filters, user is able to view all the sub domain filters
* Thumbnail on the course detail page looks blurry
* filter show more/less on field labels
* breadcrumb showing last link on mobile