### PR TITLE
fix: use course hierarchy API for unit detail and handle missing content description

### DIFF
--- a/mfes/content/src/components/Content/CourseUnitDetails.tsx
+++ b/mfes/content/src/components/Content/CourseUnitDetails.tsx
@@ -35,7 +35,7 @@ interface DetailsProps {
 export default function Details(props: DetailsProps) {
   const router = useRouter();
   const { courseId, unitId, identifier: contentId } = useParams();
-  const identifier = unitId ?? courseId;
+  const identifier = courseId;
   const [trackData, setTrackData] = useState<trackDataPorps[]>([]);
   const [selectedContent, setSelectedContent] = useState<any>(null);
   const [courseItem, setCourseItem] = useState<any>({});
@@ -51,16 +51,20 @@ export default function Details(props: DetailsProps) {
   useEffect(() => {
     const getDetails = async (identifier: string) => {
       try {
-        const resultHierarchy = await hierarchyAPI(identifier);
-        if (props?._config?.getContentData) {
-          props?._config?.getContentData(resultHierarchy);
-        }
+        let resultHierarchy: any = await hierarchyAPI(identifier, {
+          mode: 'edit',
+        });
+
         if (unitId && !props?.isHideInfoCard) {
-          const course = await hierarchyAPI(courseId as string);
-          setCourseItem(course);
+          setCourseItem(resultHierarchy);
+          if (unitId) {
+            resultHierarchy = resultHierarchy?.children?.find(
+              (item: any) => item.identifier === unitId
+            );
+          }
           const breadcrum = findCourseUnitPath({
             contentBaseUrl: props?._config?.contentBaseUrl,
-            node: course,
+            node: resultHierarchy,
             targetId: unitId as string,
             keyArray: [
               'name',
@@ -75,6 +79,9 @@ export default function Details(props: DetailsProps) {
           setBreadCrumbs(breadcrum);
         }
 
+        if (props?._config?.getContentData) {
+          props?._config?.getContentData(resultHierarchy);
+        }
         const userId = getUserId(props?._config?.userIdLocalstorageName);
         let startedOn = {};
         if (props?._config?.isEnrollmentRequired !== false) {

--- a/mfes/content/src/services/Hierarchy.ts
+++ b/mfes/content/src/services/Hierarchy.ts
@@ -109,7 +109,8 @@ interface ContentSearchResponse {
 // Define the payload
 
 export const hierarchyAPI = async (
-  doId: string
+  doId: string,
+  params?: object
 ): Promise<ContentSearchResponse> => {
   try {
     // Ensure the environment variable is defined
@@ -122,6 +123,7 @@ export const hierarchyAPI = async (
       method: 'get',
       maxBodyLength: Infinity,
       url: `${searchApiUrl}/api/course/v1/hierarchy/${doId}`,
+      params: params,
     };
 
     // Execute the request


### PR DESCRIPTION
* Replaced Unit Hierarchy API call with Course Hierarchy API to fetch unit details.
* Traversed children nodes to locate unit by ID.