### PR TITLE
Experimenttoindia : Accessbility options not working properly issue fix

### DIFF
--- a/apps/learner-web-app/src/app/themantic/themantic.css
+++ b/apps/learner-web-app/src/app/themantic/themantic.css
@@ -3,6 +3,7 @@
 
 .thematic-page {
   font-family: 'Montserrat', Arial, sans-serif !important;
+  font-size: calc(100% * var(--font-size-scale, 1));
 }
 
 .thematic-page * {

--- a/apps/learner-web-app/src/components/themantic/SearchButton.tsx
+++ b/apps/learner-web-app/src/components/themantic/SearchButton.tsx
@@ -5,7 +5,7 @@ import ClearIcon from '@mui/icons-material/Clear';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
-import SpeakableText from '@shared-lib-v2/lib/textToSpeech/SpeakableText';
+import { scaledFontSize } from '@learner/utils/scaledFontSize';
 
 interface SearchButtonProps {
   searchValue?: string;
@@ -81,13 +81,13 @@ export const SearchButton: React.FC<SearchButtonProps> = ({
                   },
                 }}
               >
-                <ClearIcon sx={{ fontSize: '20px' }} />
+                <ClearIcon sx={{ fontSize: scaledFontSize(20) }} />
               </IconButton>
             ),
             ...(_input?.InputProps ?? {}),
             sx: {
               fontFamily: 'Poppins',
-              fontSize: '18px',
+              fontSize: scaledFontSize(18),
               pl: 1,
               bgcolor: 'transparent',
               '& .MuiInputAdornment-root': {

--- a/apps/learner-web-app/src/components/themantic/content/List.tsx
+++ b/apps/learner-web-app/src/components/themantic/content/List.tsx
@@ -12,6 +12,8 @@ import Layout from '../layout/Layout';
 import SubHeader from '../subHeader/SubHeader';
 import { usePageViewCount } from '@learner/hooks/usePageViewCount';
 import { usePathname } from 'next/navigation';
+import SpeakableText from '@shared-lib-v2/lib/textToSpeech/SpeakableText';
+import { scaledFontSize } from '@learner/utils/scaledFontSize';
 
 // Dynamic import of Content component with SSR disabled
 const Content = dynamic(() => import('@Content'), {
@@ -174,12 +176,12 @@ const List: React.FC<ListProps> = ({
             >
               <Typography
                 sx={{
-                  fontSize: '20px',
+                  fontSize: scaledFontSize(20),
                   fontWeight: 600,
                   color: '#000',
                 }}
               >
-                New Arrivals
+                <SpeakableText>New Arrivals</SpeakableText>
               </Typography>
             </Box>
             <Box
@@ -243,20 +245,26 @@ const List: React.FC<ListProps> = ({
             </Box>
            
           </Box>
-        {pageViews != null && <Box sx={{ 
-          fontSize: '16px', 
-          color: '#363d47', 
-          fontWeight: 500, 
-          textAlign: 'center', 
-          mt: 4, 
-          p: 2, 
-          backgroundColor: 'rgba(255, 255, 255, 0.9)', 
-          borderRadius: '8px',
-          width: 'fit-content',
-          mx: 'auto'
-        }}>
-         Total views: {pageViews}
-        </Box>}
+        {pageViews != null && (
+          <Box
+            sx={{
+              fontSize: scaledFontSize(16),
+              color: '#363d47',
+              fontWeight: 500,
+              textAlign: 'center',
+              mt: 4,
+              p: 2,
+              backgroundColor: 'rgba(255, 255, 255, 0.9)',
+              borderRadius: '8px',
+              width: 'fit-content',
+              mx: 'auto',
+            }}
+          >
+            <SpeakableText text={`Total views: ${pageViews}`}>
+              Total views: {pageViews}
+            </SpeakableText>
+          </Box>
+        )}
         </Box>
       </Box>
     </Layout>
@@ -324,6 +332,8 @@ export const CardComponent = ({
   const finalTextTransform = textTransform || _card?.textTransform;
   const finalTitleColor = titleColor || _card?.titleColor;
   const finalMaxTitleLines = maxTitleLines || _card?.maxTitleLines || 2;
+  const cardTitle = item.name || item.title || 'Untitled';
+  const scaledTitleFontSize = scaledFontSize(finalTitleFontSize || '16px');
   const onClick = (id: string) => {
     if (handleCardClick) {
       handleCardClick(id);
@@ -370,13 +380,13 @@ export const CardComponent = ({
         </Box>
 
         {/* Title */}
-        <Tooltip title={item.name || item.title || 'Untitled'} arrow>
+        <Tooltip title={cardTitle} arrow>
           <Typography
             variant="h6"
             sx={{
               fontWeight: finalFontWeight || 400,
               textAlign: 'center',
-              fontSize: finalTitleFontSize || '16px',
+              fontSize: scaledTitleFontSize,
               letterSpacing: '1px',
               mt: 0.3,
               mb: 0.3,
@@ -392,7 +402,7 @@ export const CardComponent = ({
               wordBreak: 'break-word',
             }}
           >
-            {item.name || item.title || 'Untitled'}
+            <SpeakableText text={cardTitle}>{cardTitle}</SpeakableText>
           </Typography>
         </Tooltip>
 
@@ -402,7 +412,7 @@ export const CardComponent = ({
             sx={{
               fontWeight: 500,
               textAlign: 'center',
-              // fontSize: '14px',
+              fontSize: scaledFontSize(14),
               letterSpacing: '0.5px',
               display: '-webkit-box',
               WebkitLineClamp: finalMaxTitleLines,
@@ -418,7 +428,11 @@ export const CardComponent = ({
               visibility: englishTitle ? 'visible' : 'hidden',
             }}
           >
-            {englishTitle || 'Placeholder'}
+            {englishTitle ? (
+              <SpeakableText text={englishTitle}>{englishTitle}</SpeakableText>
+            ) : (
+              'Placeholder'
+            )}
           </Typography>
         </Tooltip>
 
@@ -446,8 +460,14 @@ export const CardComponent = ({
                 pb: 2,
               }}
             >
-              <Box sx={{ fontSize: '18px', color: '#363d47', fontWeight: 500 }}>
-                Explore
+              <Box
+                sx={{
+                  fontSize: scaledFontSize(18),
+                  color: '#363d47',
+                  fontWeight: 500,
+                }}
+              >
+                <SpeakableText>Explore</SpeakableText>
               </Box>
               <Box>
                 <img height={'20px'} src={'/images/arrow.png'} alt="arrow" />

--- a/apps/learner-web-app/src/components/themantic/subHeader/SubHeader.tsx
+++ b/apps/learner-web-app/src/components/themantic/subHeader/SubHeader.tsx
@@ -13,6 +13,11 @@ import { SearchButton } from '../SearchButton';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { logEvent } from '@learner/utils/googleAnalytics';
 import { ContentSearch } from '@learner/utils/API/contentService';
+import SpeakableText from '@shared-lib-v2/lib/textToSpeech/SpeakableText';
+import {
+  scaledFontSize,
+  scaledFontSizeResponsive,
+} from '@learner/utils/scaledFontSize';
 
 const STORAGE_KEY = 'selectedLanguage';
 type SearchLanguageItem = {
@@ -130,8 +135,14 @@ const SubHeader = ({
     <Box className='bs-container-fluid  bs-px-md-5 bs-px-sm-3' sx={{ background: '#fff' }}>
       {/* Main Title */}
       <Box
+        component="h1"
         sx={{
-          fontSize: { xs: '24px', sm: '28px', md: '32px', lg: '36px' },
+          fontSize: scaledFontSizeResponsive({
+            xs: 24,
+            sm: 28,
+            md: 32,
+            lg: 36,
+          }),
           fontWeight: 600,
           color: '#3891CE',
           fontFamily: '"Montserrat", sans-serif',
@@ -140,10 +151,12 @@ const SubHeader = ({
           py: { xs: [0, 1], sm: [0, 1] },
           wordWrap: 'break-word',
           lineHeight: 1.2,
-          pt: '5px'
+          pt: '5px',
         }}
       >
-        STEM Education for Innovation : Experimento India
+        <SpeakableText>
+          STEM Education for Innovation : Experimento India
+        </SpeakableText>
       </Box>
 
       {/* Main Container */}
@@ -189,7 +202,7 @@ const SubHeader = ({
                   boxShadow: '0 1px 4px rgba(0,0,0,0.06)',
                   '& .MuiSelect-select': {
                     padding: '4px 8px',
-                    fontSize: '14px',
+                    fontSize: scaledFontSize(14),
                     textAlign: 'center',
                   },
                   '& .MuiOutlinedInput-notchedOutline': {
@@ -202,7 +215,7 @@ const SubHeader = ({
                     border: 'none',
                   },
                   '& .MuiSvgIcon-root': {
-                    fontSize: '16px',
+                    fontSize: scaledFontSize(16),
                     color: '#222',
                   },
                 }}
@@ -233,7 +246,7 @@ const SubHeader = ({
                 variant="h6"
                 sx={{
                   fontWeight: 600,
-                  fontSize: { xs: '16px', sm: '18px' },
+                  fontSize: scaledFontSizeResponsive({ xs: 16, sm: 18 }),
                   color: 'black',
                   mb: 0.5,
                   whiteSpace: 'nowrap',
@@ -243,7 +256,9 @@ const SubHeader = ({
                   fontFamily: '"Montserrat", sans-serif',
                 }}
               >
-                {resourceCount} Resources
+                <SpeakableText text={`${resourceCount} Resources`}>
+                  {resourceCount} Resources
+                </SpeakableText>
               </Typography>
 
             </Box>

--- a/apps/learner-web-app/src/utils/scaledFontSize.ts
+++ b/apps/learner-web-app/src/utils/scaledFontSize.ts
@@ -1,0 +1,24 @@
+/**
+ * Scales a px font size with the global accessibility --font-size-scale variable.
+ */
+export function scaledFontSize(size: number | string): string {
+  const px = typeof size === 'number' ? `${size}px` : size;
+  if (px.includes('var(--font-size-scale')) {
+    return px;
+  }
+  return `calc(${px} * var(--font-size-scale, 1))`;
+}
+
+/**
+ * Builds MUI responsive fontSize values that respect accessibility scaling.
+ */
+export function scaledFontSizeResponsive(
+  sizes: Record<string, number | string>
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(sizes).map(([breakpoint, size]) => [
+      breakpoint,
+      scaledFontSize(size),
+    ])
+  );
+}


### PR DESCRIPTION
https://prathamdigitalteam.atlassian.net/browse/PS-6653

**Root cause**

1. The accessibility providers were wired correctly, but themantic UI used fixed pixel fontSize values in MUI sx props (e.g. '32px', '16px'). Those override the theme’s calc(... * var(--font-size-scale)), so changing font size had no visible effect.

3. **Text-to-speech** only works on text wrapped in SpeakableText (as on the POS home page). The main title, resource count, and card titles on /themantic were plain text, so TTS did nothing when enabled.

**Changes Made :**

1. Added scaledFontSize / scaledFontSizeResponsive helpers to apply --font-size-scale to explicit pixel sizes.
2. Updated themantic SubHeader, List (course cards, New Arrivals, views), and SearchButton to use scaled font sizes.
3. Wrapped key themantic copy in SpeakableText (main title, resource count, card titles, section labels).
4. Set base font scaling on .thematic-page in themantic.css.
