### PR TITLE
PS-6840 : Update useful links for POS

### DIFF
--- a/apps/learner-web-app/src/components/Footer/FooterWrapper.tsx
+++ b/apps/learner-web-app/src/components/Footer/FooterWrapper.tsx
@@ -7,7 +7,7 @@ const POS_ORIGINS = [
   'https://qa-pos.prathamdigital.org',
   'https://dev-pos.prathamdigital.org',
   'https://www.prathamopenschool.org',
-  'https://pos.prathamdigital.org/',
+  'https://pos.prathamdigital.org',
 ];
 
 const isPOSDomain = (): boolean => {

--- a/apps/learner-web-app/src/components/Footer/FooterWrapper.tsx
+++ b/apps/learner-web-app/src/components/Footer/FooterWrapper.tsx
@@ -1,54 +1,24 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { Footer } from './Footer';
-import { getTenantInfo } from '@learner/utils/API/ProgramService';
 
-interface TenantChild {
-  domain?: string;
-}
+const POS_ORIGINS = [
+  'https://qa-pos.prathamdigital.org',
+  'https://dev-pos.prathamdigital.org',
+  'https://www.prathamopenschool.org',
+  'https://pos.prathamdigital.org/',
+];
 
-interface Tenant {
-  children?: TenantChild[];
-}
+const isPOSDomain = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  return POS_ORIGINS.includes(window.location.origin);
+};
 
 export const FooterWrapper: React.FC = () => {
   const pathname = usePathname();
-  const [isPOSDomain, setIsPOSDomain] = useState<boolean | null>(null);
 
-  useEffect(() => {
-    const checkIfPOSDomain = async () => {
-      try {
-        const res = await getTenantInfo();
-        const tenants = res?.result || [];
-        const currentOrigin = window.location.origin;
-
-        const allChildren = tenants.flatMap((t: Tenant) => t.children || []);
-        const domainCount: Record<string, number> = {};
-        allChildren.forEach((child: TenantChild) => {
-          const d = child.domain?.replace(/\/$/, '');
-          if (d) domainCount[d] = (domainCount[d] || 0) + 1;
-        });
-
-        // A dedicated single-tenant site (like POS) has exactly one child owning this domain.
-        // Shared platforms (like PLP) have multiple children pointing to the same domain.
-        setIsPOSDomain(domainCount[currentOrigin] === 1);
-      } catch {
-        setIsPOSDomain(false);
-      }
-    };
-
-    checkIfPOSDomain();
-  }, []);
-
-  // Suppress main footer on /pos paths (local dev) or dedicated tenant domains (e.g. qa-pos).
-  if (pathname?.startsWith('/pos') || isPOSDomain) {
-    return null;
-  }
-
-  // Avoid rendering the footer strip before the domain check resolves.
-  if (isPOSDomain === null) {
+  if (pathname?.startsWith('/pos') || isPOSDomain()) {
     return null;
   }
 

--- a/apps/learner-web-app/src/components/Footer/FooterWrapper.tsx
+++ b/apps/learner-web-app/src/components/Footer/FooterWrapper.tsx
@@ -3,22 +3,45 @@
 import { usePathname } from 'next/navigation';
 import { Footer } from './Footer';
 
-const POS_ORIGINS = [
-  'https://qa-pos.prathamdigital.org',
-  'https://dev-pos.prathamdigital.org',
-  'https://www.prathamopenschool.org',
-  'https://pos.prathamdigital.org',
+const POS_HOSTNAMES = [
+  'qa-pos.prathamdigital.org',
+  'dev-pos.prathamdigital.org',
+  'prathamopenschool.org',
+  'pos.prathamdigital.org',
 ];
+
+const THEMANTIC_HOSTNAMES = [
+  'qa-themantic.prathamdigital.org',
+  'dev-themantic.prathamdigital.org',
+  'experimentoindia.prathamopenschool.org',
+];
+
+// Matches exact hostname or any subdomain (e.g. www.qa-pos.prathamdigital.org).
+// This covers http/https and www variants without listing each combination explicitly.
+const matchesHostname = (hostname: string, list: string[]): boolean =>
+  list.some((h) => hostname === h || hostname.endsWith(`.${h}`));
 
 const isPOSDomain = (): boolean => {
   if (typeof window === 'undefined') return false;
-  return POS_ORIGINS.includes(window.location.origin);
+  const hostname = window.location.hostname;
+  return matchesHostname(hostname, POS_HOSTNAMES);
+};
+
+const isThematicDomain = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  const hostname = window.location.hostname;
+  return matchesHostname(hostname, THEMANTIC_HOSTNAMES);
 };
 
 export const FooterWrapper: React.FC = () => {
   const pathname = usePathname();
 
-  if (pathname?.startsWith('/pos') || isPOSDomain()) {
+  if (
+    pathname?.startsWith('/pos') ||
+    pathname?.startsWith('/themantic') ||
+    isPOSDomain() ||
+    isThematicDomain()
+  ) {
     return null;
   }
 


### PR DESCRIPTION
**Problem**
The previous implementation used an API call (getTenantInfo) to determine whether the current site is a POS domain by counting how many child tenants share the same domain. This approach had multiple failures:

**Incomplete coverage:** https://www.prathamopenschool.org and https://dev-pos.prathamdigital.org are not registered as child tenant domain fields in the API response — only as entries in the parent tenant's uiConfig.enable_domain. So domainCount for these origins was always 0, causing the footer to incorrectly render on POS sites.
**Loading flash:** The async API call introduced a null loading state that suppressed the footer until the response resolved, causing a layout shift on every page load — even on PLP where the footer should always show.
**Unnecessary API dependency:** The footer's visibility is a static configuration concern, not dynamic data. Making a network request on every render to answer a question whose answer never changes at runtime is wasteful.

**Fix**
Removed the useEffect, useState, and getTenantInfo API call entirely. Replaced with a synchronous check against a hardcoded POS_ORIGINS list of known POS domains.

For local development, http://localhost:3003 is shared between PLP and POS — the existing pathname.startsWith('/pos') check already handles this correctly and is retained.