### PR TITLE
Issue fix due Open-in-tab feature and related to saral popup

### DIFF
--- a/apps/learner-web-app/src/app/enroll-profile-completion/page.tsx
+++ b/apps/learner-web-app/src/app/enroll-profile-completion/page.tsx
@@ -105,6 +105,38 @@ const EnrollProfileCompletionInner = () => {
       console.log('isRegisterationTestEnabled', isRegisterationTestEnabled);
 
       if (isRegisterationTestEnabled) {
+        // Enroll the user into the tenant immediately on Finish Enroll (parity with
+        // non-test programs). The eligibility test flow below still runs afterwards.
+        try {
+          const enrollUserId = localStorage.getItem('userId');
+          const enrollRoleId = localStorage.getItem('roleId');
+          const enrollTenantId = localStorage.getItem('tenantId');
+          const userTenantStatus = uiConfig?.isTenantPendingStatus;
+          if (enrollUserId && enrollRoleId && enrollTenantId) {
+            if (userTenantStatus) {
+              await enrollUserTenant({ userId: enrollUserId, tenantId: enrollTenantId, roleId: enrollRoleId, userTenantStatus: 'pending' });
+            } else {
+              await enrollUserTenant({ userId: enrollUserId, tenantId: enrollTenantId, roleId: enrollRoleId });
+            }
+            console.log('Enrolled into tenant:', enrollTenantId);
+            if (userTenantStatus) {
+              try {
+                await updateUser(enrollUserId, {
+                  userData: {},
+                  customFields: [{
+                    fieldId: 'f8dc1d5f-9b2b-412e-a22a-351bd8f14963',
+                    value: 'pending',
+                  }],
+                });
+              } catch (updateError) {
+                console.error('Failed to update pending custom field:', updateError);
+              }
+            }
+          }
+        } catch (enrollError) {
+          console.error('Enrollment failed:', enrollError);
+        }
+
         // Check if user already has an active batch across all academic years
         try {
           const academicYearList = await getAcademicYear();
@@ -280,30 +312,8 @@ const EnrollProfileCompletionInner = () => {
 
   const handleAssessmentModalClose = async () => {
     setAssessmentRequiredModal(false);
-    try {
-      const storedUserId = localStorage.getItem('userId');
-      const storedRoleId = localStorage.getItem('roleId');
-      const enrollTenantId = localStorage.getItem('tenantId');
-      const uiConfig = JSON.parse(localStorage.getItem('uiConfig') || '{}');
-      const userTenantStatus = uiConfig?.isTenantPendingStatus;
-      if (storedUserId && storedRoleId && enrollTenantId) {
-        if (userTenantStatus) {
-          await enrollUserTenant({ userId: storedUserId, tenantId: enrollTenantId, roleId: storedRoleId, userTenantStatus: 'pending' });
-        } else {
-          await enrollUserTenant({ userId: storedUserId, tenantId: enrollTenantId, roleId: storedRoleId });
-        }
-        try {
-          await updateUser(storedUserId, {
-            userData: {},
-            customFields: [{ fieldId: 'f8dc1d5f-9b2b-412e-a22a-351bd8f14963', value: 'pending' }],
-          });
-        } catch (updateError) {
-          console.error('Failed to update pending custom field:', updateError);
-        }
-      }
-    } catch (enrollError) {
-      console.error('Enrollment failed on close:', enrollError);
-    }
+    // Enrollment already happened on Finish Enroll (handleAccessProgram); here we
+    // only mark the registration test as given and continue.
     localStorage.setItem('registerationTestGiven', 'Yes');
      const isAndroid = localStorage.getItem('isAndroidApp') === 'yes';
       console.log('isAndroid check:', isAndroid);
@@ -351,39 +361,7 @@ const EnrollProfileCompletionInner = () => {
   const onAssessmentUnavailableOk = async () => {
     setAssessmentUnavailableModal(false);
     localStorage.removeItem('enrollTenantId');
-
-    try {
-      const storedUserId = localStorage.getItem('userId');
-      const storedRoleId = localStorage.getItem('roleId');
-      const enrollTenantId = localStorage.getItem('tenantId');
-      const uiConfigRaw = localStorage.getItem('uiConfig');
-      const uiConfig = uiConfigRaw ? JSON.parse(uiConfigRaw) : {};
-      const userTenantStatus = uiConfig?.isTenantPendingStatus;
-
-      if (storedUserId && storedRoleId && enrollTenantId) {
-        if (userTenantStatus) {
-          await enrollUserTenant({ userId: storedUserId, tenantId: enrollTenantId, roleId: storedRoleId, userTenantStatus: 'pending' });
-        } else {
-          await enrollUserTenant({ userId: storedUserId, tenantId: enrollTenantId, roleId: storedRoleId });
-        }
-        if (userTenantStatus) {
-          try {
-            await updateUser(storedUserId, {
-              userData: {},
-              customFields: [{
-                fieldId: 'f8dc1d5f-9b2b-412e-a22a-351bd8f14963',
-                value: 'pending',
-              }],
-            });
-          } catch (updateError) {
-            console.error('Failed to update pending custom field:', updateError);
-          }
-        }
-      }
-    } catch (enrollError) {
-      console.error('Enrollment failed on assessment unavailable:', enrollError);
-    }
-
+    // Enrollment already happened on Finish Enroll (handleAccessProgram).
     window.location.href = '/scp-dashboard';
   };
 

--- a/apps/learner-web-app/src/app/login/page.tsx
+++ b/apps/learner-web-app/src/app/login/page.tsx
@@ -414,6 +414,40 @@ const LoginPageContent = () => {
           document.cookie = `token=${token}; path=/; secure; SameSite=Strict`;
           await profileComplitionCheck();
 
+          // Fetch user details and store preferred language BEFORE the registration
+          // test check — the main-login path does this. Without it, ContentSearch in
+          // checkRegistrationTestStatus runs without the contentLanguage filter and
+          // resolves a different question set than the one the learner attempted, so
+          // getAssessmentStatus returns [] and the Saral popup wrongly re-appears.
+          try {
+            const userDetails = await getUserDetails(userResponse?.userId, true);
+            if (userDetails?.result?.userData?.customFields) {
+              userDetails.result.userData.customFields.forEach((field: any) => {
+                const { label, selectedValues } = field;
+                if (label === 'WHAT_IS_YOUR_PREFERRED_LANGUAGE') {
+                  let preferred = '';
+                  if (Array.isArray(selectedValues) && selectedValues.length > 0) {
+                    const first = selectedValues[0] as unknown;
+                    preferred =
+                      typeof first === 'string'
+                        ? first
+                        : (first as { value?: string })?.value ?? String(first);
+                  } else if (typeof selectedValues === 'string') {
+                    preferred = selectedValues;
+                  }
+                  if (preferred) {
+                    localStorage.setItem('preferred_language', preferred);
+                  }
+                }
+              });
+            }
+          } catch (error) {
+            console.error(
+              'Failed to fetch user details for preferred language',
+              error
+            );
+          }
+
           const assessmentStatus = await checkRegistrationTestStatus(
             uiConfig,
             enrolledTenant.tenantName,

--- a/apps/learner-web-app/src/app/reattempt-check/page.tsx
+++ b/apps/learner-web-app/src/app/reattempt-check/page.tsx
@@ -4,8 +4,6 @@ import React, { useEffect, useState } from 'react';
 import { Box, Typography } from '@mui/material';
 import { useRouter } from 'next/navigation';
 import { getAssessmentStatus } from '@learner/utils/API/AssesmentService';
-import { enrollUserTenant } from '@learner/utils/API/EnrollmentService';
-import { updateUser } from '@learner/utils/API/userService';
 import Loader from '@learner/components/Loader/Loader';
 import SimpleModal from '@learner/components/SimpleModal/SimpleModal';
 import { useTranslation } from '@shared-lib';
@@ -43,44 +41,6 @@ console.log('Assessment status result:', result, 'Reattempt allowed:', registrat
   );
 };
 
-const enrollIntoTenant = async () => {
-  try {
-    const storedUserId = localStorage.getItem('userId');
-    const storedRoleId = localStorage.getItem('roleId');
-    const tenantId = localStorage.getItem('tenantId');
-    const uiConfig = JSON.parse(localStorage.getItem('uiConfig') || '{}');
-    const userTenantStatus = uiConfig?.isTenantPendingStatus;
-
-    if (!storedUserId || !storedRoleId || !tenantId) {
-      console.error('enrollIntoTenant: missing required fields');
-      return;
-    }
-
-    if (userTenantStatus) {
-      await enrollUserTenant({ userId: storedUserId, tenantId, roleId: storedRoleId, userTenantStatus: 'pending' });
-    } else {
-      await enrollUserTenant({ userId: storedUserId, tenantId, roleId: storedRoleId });
-    }
-    console.log('Enrolled into tenant:', tenantId);
-
-    // Update user with pending custom field after enrollment
-    try {
-      await updateUser(storedUserId, {
-        userData: {},
-        customFields: [{
-          fieldId: 'f8dc1d5f-9b2b-412e-a22a-351bd8f14963',
-          value: 'pending',
-        }],
-      });
-      console.log('Pending custom field updated for user:', storedUserId);
-    } catch (updateError) {
-      console.error('Failed to update pending custom field:', updateError);
-    }
-  } catch (error) {
-    console.error('enrollIntoTenant failed:', error);
-  }
-};
-
 const ReattemptCheckPage = () => {
   const router = useRouter();
   const { t } = useTranslation();
@@ -103,8 +63,7 @@ const ReattemptCheckPage = () => {
           const isAndroid = localStorage.getItem('isAndroidApp') === 'yes';
           const landingPage = localStorage.getItem('landingPage') || '/home';
 
-          // Enroll user into the tenant now that assessment is complete
-          await enrollIntoTenant();
+          // Enrollment already happened on Finish Enroll (enroll-profile-completion).
 
           if (isAndroid) {
             let refreshToken = localStorage.getItem('refreshTokenForAndroid');
@@ -139,9 +98,8 @@ const ReattemptCheckPage = () => {
   }, [router]);
 
   const handleContinue = async () => {
-        await enrollIntoTenant();
-
-    // Enroll user into the tenant when they choose to continue without reattempting
+    // Enrollment already happened on Finish Enroll (enroll-profile-completion);
+    // continuing without reattempting only needs the redirect / Android handoff.
        const isAndroid = localStorage.getItem('isAndroidApp') === 'yes';
       console.log('isAndroid check:', isAndroid);
       

--- a/apps/learner-web-app/src/components/AttemptAssessmentButton/AttemptAssessmentButton.tsx
+++ b/apps/learner-web-app/src/components/AttemptAssessmentButton/AttemptAssessmentButton.tsx
@@ -86,7 +86,13 @@ const AttemptAssessmentButton: React.FC = () => {
         contentId: identifier,
       });
 
-      if (Array.isArray(result) && result.length === 0) {
+      // Show the button while attempts remain, using the same allowance the
+      // reattempt popup uses (uiConfig.registrationTestReattempt) so the two agree.
+      const registrationTestReattempt = Number(
+        uiConfig?.registrationTestReattempt ?? 0
+      );
+
+      if (Array.isArray(result) && result.length < registrationTestReattempt) {
         localStorage.setItem('registerationTestQuestionSetIdentifier', identifier);
         setQuestionSetIdentifier(identifier);
         setIsContentAvailable(true);

--- a/apps/learner-web-app/src/components/Content/Player.tsx
+++ b/apps/learner-web-app/src/components/Content/Player.tsx
@@ -503,6 +503,7 @@ const App = ({
           unitId={unitId}
           mimeType={mimeType}
           exitLink={exitLink || returnUrl || activeLink}
+          previousPage={previousPage}
           {..._config?.player}
           isPortrait={isPortrait}
           isVideo={isVideo}
@@ -724,6 +725,7 @@ const PlayerBox = ({
   isPortrait,
   isVideo,
   exitLink,
+  previousPage,
 }: any) => {
   const router = useRouter();
   const { t } = useTranslation();
@@ -740,6 +742,15 @@ const PlayerBox = ({
     exitLink && typeof window !== 'undefined'
       ? new URL(exitLink, window.location.origin).href
       : exitLink;
+
+  // previousPage is where the learner should return when they abandon the flow
+  // (e.g. exiting an assessment before completing). Resolve to an absolute URL on
+  // the parent origin — same reason as absoluteExitLink above — so the player can
+  // navigate back to the correct domain from inside the cross-origin iframe.
+  const absolutePreviousPage =
+    previousPage && typeof window !== 'undefined'
+      ? new URL(previousPage, window.location.origin).href
+      : previousPage;
 
   // Determine aspectRatio based on mimeType and mobile mode
   const getAspectRatio = () => {
@@ -831,6 +842,10 @@ const PlayerBox = ({
             }${
               absoluteExitLink
                 ? `&exitLink=${encodeURIComponent(absoluteExitLink)}`
+                : ''
+            }${
+              absolutePreviousPage
+                ? `&previousPage=${encodeURIComponent(absolutePreviousPage)}`
                 : ''
             }${
               userIdLocalstorageName

--- a/mfes/players/src/components/players/SunbirdQuMLPlayer.tsx
+++ b/mfes/players/src/components/players/SunbirdQuMLPlayer.tsx
@@ -118,9 +118,44 @@ const SunbirdQuMLPlayer = ({
   }, [playerConfig]);
 
   React.useEffect(() => {
+    // The QuML player posts a `maxScore` message when the assessment is submitted.
+    // Use it to tell a completed exit (→ exitLink, e.g. /reattempt-check) apart
+    // from an abandoned exit (→ previousPage, e.g. /scp-dashboard).
+    let isAssessmentCompleted = false;
     const handleMessage = (event: any) => {
       const data = JSON.parse(event?.data);
+
+      // [QuML-DIAG] TEMPORARY instrumentation — remove after analysis.
+      // Logs every message the embedded sunbird-quml-player posts, so we can
+      // compare the exact sequence for a genuine COMPLETION vs an ABORT (Exit
+      // mid-assessment). We want to find a reliable "actually finished" signal
+      // (e.g. progress === 100 / all questions answered) rather than relying on
+      // "a maxScore or SUMMARY message arrived", which may fire in both cases.
+      try {
+        const tele = data?.data ?? {};
+        const edata = tele?.edata ?? {};
+        const progressFromSummary = Array.isArray(edata?.summary)
+          ? edata.summary.find((s: any) => s?.progress != null)?.progress
+          : undefined;
+        const progressFromExtra = Array.isArray(edata?.extra)
+          ? edata.extra.find((e: any) => e?.id === 'progress')?.value
+          : undefined;
+        console.log('[QuML-DIAG] message', {
+          hasMaxScore: data?.maxScore !== undefined,
+          maxScore: data?.maxScore,
+          eid: tele?.eid,
+          edataType: edata?.type,
+          mid: tele?.mid,
+          progressFromSummary,
+          progressFromExtra,
+          payload: data,
+        });
+      } catch (diagErr) {
+        console.log('[QuML-DIAG] could not inspect message', diagErr, event?.data);
+      }
+
       if (data?.maxScore !== undefined) {
+        isAssessmentCompleted = true;
         createAssessmentTracking({
           ...data,
           courseId,
@@ -128,8 +163,19 @@ const SunbirdQuMLPlayer = ({
           userId,
         });
       } else if (data?.data?.edata?.type === 'EXIT') {
-        handleExitEvent();
+        handleExitEvent({ preferPreviousPage: !isAssessmentCompleted });
       } else if (data?.data?.mid) {
+        // An aborted assessment is never submitted, so `maxScore` /
+        // createAssessmentTracking never fires. Its END/SUMMARY telemetry must NOT
+        // mark the course content complete. Only forward completion telemetry once
+        // the assessment has actually been submitted (isAssessmentCompleted). START
+        // and other events still flow through (they record in-progress).
+        const telemetryEid = data?.data?.eid;
+        const isCompletionTelemetry =
+          telemetryEid === 'END' || telemetryEid === 'SUMMARY';
+        if (isCompletionTelemetry && !isAssessmentCompleted) {
+          return;
+        }
         handleTelemetryEventQuml(data, {
           courseId,
           unitId,

--- a/mfes/players/src/components/utils/Helper.ts
+++ b/mfes/players/src/components/utils/Helper.ts
@@ -40,11 +40,22 @@ export const debounce = <T extends (...args: any[]) => any>(
   };
 };
 
-export const handleExitEvent = () => {
+export const handleExitEvent = (options?: { preferPreviousPage?: boolean }) => {
   // Prefer exitLink/activeLink from the iframe URL — set by the parent player page.
   // This avoids using sessionStorage['previousPage'] which may point to a different domain.
   if (typeof window !== 'undefined') {
     const params = new URLSearchParams(window.location.search);
+    // Abandoned flow (e.g. exiting an assessment before completing): return to
+    // previousPage (where the learner launched from) instead of the
+    // post-completion gate (exitLink, e.g. /reattempt-check).
+    if (options?.preferPreviousPage) {
+      const previousUrl = params.get('previousPage');
+      if (previousUrl) {
+        const target = window.top ?? window;
+        target.location.href = previousUrl;
+        return;
+      }
+    }
     const exitUrl = params.get('exitLink') || params.get('activeLink');
     if (exitUrl) {
       const target = window.top ?? window;

--- a/mfes/players/src/services/TelemetryService.ts
+++ b/mfes/players/src/services/TelemetryService.ts
@@ -98,6 +98,10 @@ export const getTelemetryEvents = async (
   }
 
   if (eid === 'END' || (contentType === 'quml' && eid === 'SUMMARY')) {
+    // [QuML-DIAG] TEMPORARY — remove after analysis. Confirms that the
+    // completion-tracking branch fires (which marks the course/unit complete),
+    // and on which event, so we can verify it also fires on an aborted exit.
+    console.log('[QuML-DIAG] completion branch fired', { contentType, eid, identifier });
     try {
       const detailsObject: any[] = [];
 


### PR DESCRIPTION
# SCP Registration Test & Assessment Tracking — Bug Fixes

_Branch: `redirect-issue`_

This document describes the bugs fixed on this branch (Second Chance Program eligibility/"Saral" test, assessment player exit, and course-content tracking). Each section is self-contained: **Symptom → Root cause → Fix**.

---

## 1. Mid-assessment "Exit" redirected the learner to the wrong page

**Symptom**
Clicking **Exit** while an assessment was still in progress (abandoning it) redirected to `/reattempt-check` instead of returning the learner to where they launched from (e.g. `/scp-dashboard` or `/programs`). Previously an abandoned test returned to the dashboard.

**Root cause**
Introduced by the combination of two PRs:
- **PR #3079 (PS-6934, "Open in New Tab")** started forwarding `exitLink` into the sbplayer iframe URL and made exit prefer `exitLink`.
- **PR #3234 (PS-7122)** kept `handleExitEvent` reading `exitLink` from the iframe URL first.

Both a *completed* exit and an *abandoned* exit fire the same `EXIT` event, so both resolved to a single destination — `exitLink` (`/reattempt-check`). Before these PRs, `handleExitEvent` only used `sessionStorage['previousPage']`, so an abandoned test went back to the previous page.

**Fix**
Distinguish the two cases and route them to different destinations:
- `mfes/players/src/components/utils/Helper.ts` — `handleExitEvent` now accepts `{ preferPreviousPage }`. When set, it redirects to `previousPage` (from the iframe URL) before falling back to `exitLink`.
- `mfes/players/src/components/players/SunbirdQuMLPlayer.tsx` — tracks `isAssessmentCompleted` (set when the QuML `maxScore`/submission message fires) and calls `handleExitEvent({ preferPreviousPage: !isAssessmentCompleted })`.
  - Abandoned exit → `previousPage` (e.g. `/scp-dashboard`).
  - Completed exit → `exitLink` (e.g. `/reattempt-check`).
- `apps/learner-web-app/src/components/Content/Player.tsx` — forwards `previousPage` into the sbplayer iframe, resolved to an absolute URL on the parent origin (same treatment as `exitLink`), so the players MFE can read it.

---

## 2. Aborting a course assessment marked the content "Completed"

**Symptom**
Opening a question-set (assessment) inside a course and exiting **before finishing** marked the content/course as **Completed** on localhost, while on QA the same action correctly left it **In Progress**.

**Root cause**
On exit, the QuML player emits an `END`/`SUMMARY` telemetry event. `getTelemetryEvents` treats a `quml` `SUMMARY` (or `END`) as a completion event and writes content tracking (which the backend turns into a `completed_list` entry) — **without verifying the assessment was actually submitted**. The progress guard that might have filtered incomplete events was commented out, and for a question set "progress" reflects score, not completion, so it was not a reliable discriminator anyway.

The completion logic itself is old (pre-dates the PRs). What made it *fire on abort on localhost* was PR #3234's change to redirect the **top** window (`window.top.location.href`) instead of the players iframe: that keeps the iframe alive long enough for the abort's completion write to flush. QA (old code) navigates the iframe itself, killing the write before it is queued — which is why QA stayed "In Progress."

**Fix**
`mfes/players/src/components/players/SunbirdQuMLPlayer.tsx` — forward the completion telemetry (`END`/`SUMMARY`) to content tracking **only when the assessment was actually submitted** (`isAssessmentCompleted`, i.e. the `maxScore` / `createAssessmentTracking` submission fired). An aborted attempt never submits, so its completion telemetry is suppressed and the content stays **In Progress**. A genuine completion still records — even with a score of 0.

**Note:** A progress-based guard (`progress === 100`) was tried first and reverted — a legitimately completed test with score 0 has progress ≠ 100, so the guard wrongly blocked real completions. The **submission signal (`maxScore`)** is the correct discriminator, not progress.

---

## 3. SCP "Finish Enroll" did not enroll the user until later

**Symptom**
For SCP (which requires an eligibility test), clicking **Finish Enroll** did not enroll the user into the tenant; enrollment was deferred until after the test was taken or the modal was dismissed.

**Requested behavior**
Enroll into the tenant **immediately** on Finish Enroll, while still requiring the eligibility test.

**Fix**
- `apps/learner-web-app/src/app/enroll-profile-completion/page.tsx` — in the registration-test branch of `handleAccessProgram`, call `enrollUserTenant` immediately (mirroring the non-test `else` branch), then continue into the eligibility-test flow.
- Removed the now-redundant deferred enrollment calls so the user is enrolled **exactly once**:
  - `handleAssessmentModalClose` and `onAssessmentUnavailableOk` (in the same file)
  - the `enrollIntoTenant` function and both its call sites in `apps/learner-web-app/src/app/reattempt-check/page.tsx` (plus its now-unused imports)
- Non-enrollment side effects were preserved (`registerationTestGiven` flag, redirects, Android WebView handoff).

---

## 4. Dashboard "Attempt Assessment" button vanished after the first attempt

**Symptom**
With 2 attempts allowed, after completing **1** attempt the "Attempt Assessment" button on the SCP dashboard disappeared, even though the learner still had 1 attempt left.

**Root cause**
`AttemptAssessmentButton` decided visibility with `result.length === 0` (show only if never attempted), ignoring the `registrationTestReattempt` allowance.

**Fix**
`apps/learner-web-app/src/components/AttemptAssessmentButton/AttemptAssessmentButton.tsx` — changed the condition to `result.length < registrationTestReattempt` (from `uiConfig`). The button now stays visible while attempts remain and hides once the limit is reached — consistent with the reattempt-check page.

---

## 5. Program-specific login re-showed the "Saral Test" popup for users who already completed it

**Symptom**
A user who completed **both** eligibility-test attempts got **no** popup via main login, program switch, or the access-program button (correct), but logging in from the **program-specific** login page (`/login?tenantId=...`) still showed the "Start the Saral Test" popup.

**Root cause**
The **main-login** path calls `getUserDetails` and stores `localStorage['preferred_language']` **before** running `checkRegistrationTestStatus`. The **program-specific** login path skipped that call.

`checkRegistrationTestStatus` → `ContentSearch` uses `preferred_language` as the `contentLanguage` filter. Without it, the program-login flow resolved a **different** eligibility question set than the one the learner actually attempted, so `getAssessmentStatus` for that question set returned `[]` (no attempts) and the popup showed.

Confirmed via network:
- `localStorage['registerationTestQuestionSetIdentifier']` and the resolved id matched the completed test.
- `/tracking/assessment/search` returned `[]` for the question set the program-login flow resolved, while the main-login flow found the 2 records.

**Fix**
`apps/learner-web-app/src/app/login/page.tsx` — in the program-specific login branch (`if (enrolledTenant)`), fetch `getUserDetails` and set `preferred_language` **before** calling `checkRegistrationTestStatus`, mirroring the main-login path. Both flows now resolve the same question set and find the recorded attempts, so a user who completed the test is no longer re-prompted.

---

