### PR TITLE
PS-7172 : Issue: Archived Content Reviewer Still Receiving Content Approval Emails

### DIFF
--- a/mfes/editors/src/services/userServices.ts
+++ b/mfes/editors/src/services/userServices.ts
@@ -73,7 +73,10 @@ export const getUserDetailsInfo = async (
  export const fetchCCTAList = async(board?: any, subject?: any) => {
     try{
         const filter: any = {
-            role: Role.CCTA
+            role: Role.CCTA,
+            // exclude reviewers archived/inactive in the current program (tenant),
+            // so they no longer receive content review notifications
+            tenantStatus: ['active']
         }
         if (board) {
           filter.board = [board];


### PR DESCRIPTION
**Root cause**

Archiving a Content Reviewer sets their program-scoped tenantStatus to archived via PATCH /user-tenant/status; it never touches the user's global status, and their Content reviewer role mapping stays intact. The fetchCCTAList() helper that builds the review-email recipient list filtered /user/list only by role, board, subject and tenantId — **with no status filter** at all. Archived reviewers therefore kept coming back in the list and were mailed on every onContentReview notification.

Solution

- **Added tenantStatus: ['active']** to the /user/list filter in fetchCCTAList() (mfes/editors/src/services/userServices.ts), so reviewers archived from the current program are excluded from the recipient list. Used tenantStatus rather than status because archival is per-program — a reviewer archived in one program but active in another correctly still receives that program's emails.
- Fixes all three content types with one change, since GenericEditor, QuestionSetEditor and CollectionEditor all build recipients from fetchCCTAList() — no editor-component changes required.

