### PR TITLE
PS-7248 : SCP AKP - Saral test popup appear for the learner who has assigned to batch

### DIFF
--- a/apps/learner-web-app/src/components/EnrollProgramCarousel/EnrollProgramCarousel.tsx
+++ b/apps/learner-web-app/src/components/EnrollProgramCarousel/EnrollProgramCarousel.tsx
@@ -105,7 +105,12 @@ const EnrollProgramCarousel = ({
     | 'assessmentPending'
     | 'assessmentUnavailable';
 
-  const checkRegistrationTestStatus = async (
+  /**
+   * Runs the gate assuming the tenant context in localStorage already points at the
+   * program being gated. Always call it through checkRegistrationTestStatus, which
+   * guarantees that.
+   */
+  const resolveRegistrationTestStatus = async (
     uiConfig: any,
     enrolledProgramName?: string,
     tenantDataDetails?: any
@@ -231,6 +236,47 @@ console.log('result=====>', result);
     } catch (error) {
       console.error('checkRegistrationTestStatus: getAssessmentStatus failed', error);
       return 'clear'; // On API failure, allow access gracefully
+    }
+  };
+
+  const checkRegistrationTestStatus = async (
+    uiConfig: any,
+    enrolledProgramName?: string,
+    tenantDataDetails?: any
+  ): Promise<RegistrationTestStatus> => {
+    // The batch / question-set lookups inside the gate are tenant-scoped: the axios
+    // interceptor stamps `tenantid` from localStorage on every request. The Android
+    // branch of handleAccessProgram delegates the actual program switch to native, so
+    // localStorage still points at whatever program the previous flow left behind (e.g.
+    // a program the user just enrolled into) — the active-batch lookup then queries the
+    // wrong tenant, finds no batch, and wrongly shows the "test unavailable" popup.
+    // Point the tenant context at the program being gated, then put it back.
+    const targetTenantId = tenantDataDetails?.tenantId;
+    const previousTenantId = localStorage.getItem('tenantId');
+    const previousAcademicYearId = localStorage.getItem('academicYearId');
+    // Callers that already switched the app into the target program (web path) keep
+    // their context; only a temporary override has to be undone.
+    const shouldRestoreTenantContext = Boolean(
+      targetTenantId && previousTenantId && previousTenantId !== targetTenantId
+    );
+
+    if (targetTenantId) {
+      localStorage.setItem('tenantId', targetTenantId);
+    }
+
+    try {
+      return await resolveRegistrationTestStatus(
+        uiConfig,
+        enrolledProgramName,
+        tenantDataDetails
+      );
+    } finally {
+      if (shouldRestoreTenantContext && previousTenantId) {
+        localStorage.setItem('tenantId', previousTenantId);
+        if (previousAcademicYearId) {
+          localStorage.setItem('academicYearId', previousAcademicYearId);
+        }
+      }
     }
   };
 


### PR DESCRIPTION
**Root cause**

- The gate's "does this learner already have an active batch?" check calls getAcademicYear() + getCohortList(), and both are tenant-scoped — the axios interceptor stamps the tenantid header from localStorage.tenantId on every request ([Interceptor.ts:40](vscode-webview://147opgi0rh77f0icu2cjo514oa8cm719q2crlv4iic9okfbq5ksh/libs/shared-lib/src/lib/Services/Interceptor.ts#L40)).
- Enrolling into Vocational Training overwrites localStorage.tenantId with the VT tenant ([EnrollProgramCarousel.tsx:663](vscode-webview://147opgi0rh77f0icu2cjo514oa8cm719q2crlv4iic9okfbq5ksh/apps/learner-web-app/src/components/EnrollProgramCarousel/EnrollProgramCarousel.tsx#L663)) and nothing ever restores it.
- On Android, handleAccessProgram runs the gate before the program switch (native handles the switch via ACCESS_PROGRAM_EVENT), so the batch lookup went out under the VT tenant → no SCP batch found → fell through to the language-based question-set search → none in English → wrong popup. The web path sets tenantId to the target program first, which is why the bug was Android-only.

**Fix**

- Existing gate logic kept as-is, renamed to resolveRegistrationTestStatus — no behaviour change inside it.
- New checkRegistrationTestStatus wrapper ([lines 242-281](vscode-webview://147opgi0rh77f0icu2cjo514oa8cm719q2crlv4iic9okfbq5ksh/apps/learner-web-app/src/components/EnrollProgramCarousel/EnrollProgramCarousel.tsx#L242-L281)) sets localStorage.tenantId to the tenant of the program being gated before running the gate, so the batch lookup always queries the right program.
- A finally restores tenantId + academicYearId when the override was temporary, so a blocked gate can't leave the webview pointing at the wrong program. The web path is a no-op (it already had the right tenant set), so nothing regresses there.