### PR TITLE
Implement accordion UI for Assessment Attempts and Registration Success Card; add batch assignment check

### DIFF
--- a/apps/learner-web-app/src/components/AssessmentAttempts/AssessmentAttempts.tsx
+++ b/apps/learner-web-app/src/components/AssessmentAttempts/AssessmentAttempts.tsx
@@ -2,19 +2,19 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
-  Chip,
-  Divider,
   Skeleton,
   Stack,
   Typography,
   useTheme,
 } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
-import AutorenewIcon from '@mui/icons-material/Autorenew';
+import EmojiEventsOutlinedIcon from '@mui/icons-material/EmojiEventsOutlined';
 import VpnKeyIcon from '@mui/icons-material/VpnKey';
-import LockIcon from '@mui/icons-material/Lock';
 import { usePathname } from 'next/navigation';
 import { useTranslation } from '@shared-lib';
 import { ContentSearch } from '@learner/utils/API/contentService';
@@ -25,20 +25,30 @@ import {
   mapAttemptCards,
   TOTAL_ATTEMPT_SLOTS,
 } from '@learner/utils/helpers/assessmentAttemptHelpers';
+import { checkUserHasActiveBatch } from '@learner/utils/helpers/cohortAssignmentHelper';
+import { useSharedAccordionState } from '@learner/utils/hooks/useSharedAccordionState';
 import AttemptAssessmentButton from '@learner/components/AttemptAssessmentButton/AttemptAssessmentButton';
 
 type LoadState = 'idle' | 'loading' | 'loaded' | 'error' | 'notApplicable';
 
-type BadgeVariant = 'completed' | 'bestScore' | 'latest' | 'notAttempted' | 'locked';
+type PillVariant = 'completed' | 'notAttempted';
 
-const AssessmentAttempts: React.FC = () => {
+interface AssessmentAttemptsProps {
+  onVisibilityChange?: (isVisible: boolean) => void;
+}
+
+const AssessmentAttempts: React.FC<AssessmentAttemptsProps> = ({
+  onVisibilityChange,
+}) => {
   const { t } = useTranslation();
   const theme = useTheme();
   const { customColors } = theme.palette;
   const pathname = usePathname();
+  const [isOpen, setIsOpen] = useSharedAccordionState();
   const [loadState, setLoadState] = useState<LoadState>('idle');
   const [attemptCards, setAttemptCards] = useState(mapAttemptCards([]));
   const [completedCount, setCompletedCount] = useState(0);
+  const [isBatchAssigned, setIsBatchAssigned] = useState(false);
 
   const loadAssessmentAttempts = useCallback(async () => {
     if (typeof window === 'undefined') return;
@@ -71,19 +81,22 @@ const AssessmentAttempts: React.FC = () => {
       const programFilter = [userProgram, 'Second Chance'];
       const preferredLanguage = localStorage.getItem('preferred_language');
 
-      const response = await ContentSearch({
-        query: '',
-        filters: {
-          status: ['Live'],
-          primaryCategory: ['Practice Question Set'],
-          assessmentType: 'Eligibility Test',
-          program: programFilter,
-          ...(preferredLanguage ? { contentLanguage: [preferredLanguage] } : {}),
-        },
-        sort_by: { lastUpdatedOn: 'desc' },
-        limit: 1,
-        offset: 0,
-      });
+      const [response, hasActiveBatch] = await Promise.all([
+        ContentSearch({
+          query: '',
+          filters: {
+            status: ['Live'],
+            primaryCategory: ['Practice Question Set'],
+            assessmentType: 'Eligibility Test',
+            program: programFilter,
+            ...(preferredLanguage ? { contentLanguage: [preferredLanguage] } : {}),
+          },
+          sort_by: { lastUpdatedOn: 'desc' },
+          limit: 1,
+          offset: 0,
+        }),
+        checkUserHasActiveBatch(storedUserId),
+      ]);
 
       const identifier = response?.result?.QuestionSet?.[0]?.identifier;
       if (!identifier) {
@@ -99,6 +112,15 @@ const AssessmentAttempts: React.FC = () => {
       });
 
       const attempts = Array.isArray(result) ? result : [];
+
+      // A batch-assigned learner with no completed attempts has nothing to show —
+      // hide the section entirely rather than a section with only locked/empty pills.
+      if (hasActiveBatch && attempts.length === 0) {
+        setLoadState('notApplicable');
+        return;
+      }
+
+      setIsBatchAssigned(hasActiveBatch);
       setAttemptCards(mapAttemptCards(attempts));
       setCompletedCount(Math.min(attempts.length, TOTAL_ATTEMPT_SLOTS));
       setLoadState('loaded');
@@ -112,228 +134,236 @@ const AssessmentAttempts: React.FC = () => {
     loadAssessmentAttempts();
   }, [loadAssessmentAttempts, pathname]);
 
+  useEffect(() => {
+    if (loadState === 'idle') return;
+    onVisibilityChange?.(loadState !== 'notApplicable');
+  }, [loadState, onVisibilityChange]);
+
   if (loadState === 'idle' || loadState === 'notApplicable') {
     return null;
   }
 
-  const containerSx = {
+  const accordionSx = {
     bgcolor: customColors.assessmentContainerBackground,
     border: `1px solid ${customColors.assessmentContainerBorder}`,
-    borderRadius: 3,
-    overflow: 'hidden',
+    borderRadius: '12px !important',
     width: '100%',
     flexGrow: 1,
-    display: 'flex',
-    flexDirection: 'column',
+    boxSizing: 'border-box',
+    '&:before': { display: 'none' },
   };
+
+  // Once batch-assigned, a partial (1/2) count is meaningless — the batch
+  // already decided the learner's path, so only show the count once both
+  // attempts are completed.
+  const showCompletionCount =
+    loadState === 'loaded' && (!isBatchAssigned || completedCount === attemptCards.length);
+
+  const summary = (
+    <AccordionSummary
+      expandIcon={<ExpandMoreIcon />}
+      sx={{
+        px: { xs: 2, md: 2.5 },
+        minHeight: 'auto',
+        '& .MuiAccordionSummary-content': {
+          my: 1,
+          alignItems: 'baseline',
+          gap: 1,
+          flexWrap: 'wrap',
+        },
+      }}
+    >
+      <Typography variant="subtitle1" sx={{ fontWeight: 700, fontSize: '14px' }}>
+        {t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.TITLE')}
+      </Typography>
+      {showCompletionCount && (
+        <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: '12px' }}>
+          {completedCount} {t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.OF')}{' '}
+          {attemptCards.length}{' '}
+          {t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.COMPLETED_LOWERCASE')}
+        </Typography>
+      )}
+    </AccordionSummary>
+  );
 
   if (loadState === 'loading') {
     return (
-      <Box sx={{ ...containerSx, p: { xs: 2, md: 2.5 } }}>
-        <Skeleton variant="text" width={180} height={28} />
-        <Stack spacing={1.5} mt={1.5}>
-          <Skeleton variant="rounded" width="100%" height={48} />
-          <Skeleton variant="rounded" width="100%" height={48} />
-        </Stack>
-      </Box>
+      <Accordion
+        expanded={isOpen}
+        onChange={(_event, expanded) => setIsOpen(expanded)}
+        disableGutters
+        elevation={0}
+        sx={accordionSx}
+      >
+        {summary}
+        <AccordionDetails sx={{ px: { xs: 2, md: 2.5 }, pt: 0 }}>
+          <Stack direction="row" spacing={1} flexWrap="wrap">
+            <Skeleton variant="rounded" width={160} height={32} />
+            <Skeleton variant="rounded" width={160} height={32} />
+          </Stack>
+        </AccordionDetails>
+      </Accordion>
     );
   }
 
   if (loadState === 'error') {
     return (
-      <Box sx={{ ...containerSx, p: { xs: 2, md: 2.5 } }}>
-        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-          {t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.LOAD_ERROR')}
-        </Typography>
-      </Box>
+      <Accordion
+        expanded={isOpen}
+        onChange={(_event, expanded) => setIsOpen(expanded)}
+        disableGutters
+        elevation={0}
+        sx={accordionSx}
+      >
+        {summary}
+        <AccordionDetails sx={{ px: { xs: 2, md: 2.5 }, pt: 0 }}>
+          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+            {t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.LOAD_ERROR')}
+          </Typography>
+        </AccordionDetails>
+      </Accordion>
     );
   }
 
-  const renderBadge = (variant: BadgeVariant, label: string) => {
-    const variantStyles: Record<
-      BadgeVariant,
-      { bg: string; text: string; icon: React.ReactElement }
-    > = {
-      completed: {
-        bg: customColors.assessmentCompletedBadgeBg,
-        text: customColors.assessmentCompletedBadgeText,
-        icon: <CheckCircleIcon sx={{ fontSize: '14px !important' }} />,
-      },
-      bestScore: {
-        bg: customColors.assessmentBestScoreBadgeBg,
-        text: customColors.assessmentBestScoreBadgeText,
-        icon: <EmojiEventsIcon sx={{ fontSize: '14px !important' }} />,
-      },
-      latest: {
-        bg: customColors.assessmentLatestBadgeBg,
-        text: customColors.assessmentLatestBadgeText,
-        icon: <AutorenewIcon sx={{ fontSize: '14px !important' }} />,
-      },
-      notAttempted: {
-        bg: customColors.assessmentNotAttemptedBadgeBg,
-        text: customColors.assessmentNotAttemptedBadgeText,
-        icon: <VpnKeyIcon sx={{ fontSize: '14px !important' }} />,
-      },
-      locked: {
-        bg: customColors.assessmentLockedBadgeBg,
-        text: customColors.assessmentLockedBadgeText,
-        icon: <LockIcon sx={{ fontSize: '14px !important' }} />,
-      },
-    };
-    const style = variantStyles[variant];
+  const pillStyles: Record<PillVariant, { bg: string; text: string }> = {
+    completed: {
+      bg: customColors.assessmentCompletedBadgeBg,
+      text: customColors.assessmentCompletedBadgeText,
+    },
+    notAttempted: {
+      bg: customColors.assessmentNotAttemptedBadgeBg,
+      text: customColors.assessmentNotAttemptedBadgeText,
+    },
+  };
+
+  // Trophy goes to the completed attempt with the highest score; ties break to
+  // the latest completed attempt; no trophy at all if every completed score is 0.
+  const completedAttempts = attemptCards.filter((attempt) => attempt.isAttempted);
+  const highestScore = completedAttempts.reduce(
+    (max, attempt) => Math.max(max, attempt.score ?? 0),
+    0
+  );
+  const trophyAttemptNumber =
+    highestScore > 0
+      ? completedAttempts
+          .filter((attempt) => (attempt.score ?? 0) === highestScore)
+          .reduce((latest, attempt) =>
+            attempt.attemptNumber > latest.attemptNumber ? attempt : latest
+          ).attemptNumber
+      : null;
+
+  const renderAttemptPill = (attempt: AssessmentAttemptCardData) => {
+    const variant: PillVariant = attempt.isAttempted ? 'completed' : 'notAttempted';
+    const style = pillStyles[variant];
+
+    const statusLabel = attempt.isAttempted
+      ? t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.COMPLETED')
+      : t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.NOT_ATTEMPTED');
+
+    const StatusIcon = attempt.isAttempted ? CheckCircleIcon : VpnKeyIcon;
 
     return (
-      <Chip
-        label={label}
-        icon={style.icon}
-        size="small"
+      <Stack
+        key={attempt.attemptNumber}
+        direction="row"
+        alignItems="center"
+        spacing={0.75}
         sx={{
           bgcolor: style.bg,
           color: style.text,
-          fontWeight: 600,
-          fontSize: '12px',
-          height: '24px',
-          '& .MuiChip-icon': { color: style.text },
-        }}
-      />
-    );
-  };
-
-  const renderAttemptRow = (attempt: AssessmentAttemptCardData, index: number) => {
-    const isNextAttempt =
-      !attempt.isAttempted && !attempt.isLocked && index === completedCount;
-
-    const scoreDisplay =
-      attempt.isAttempted && attempt.score !== null && attempt.totalMaxScore !== null
-        ? `${attempt.score}/${attempt.totalMaxScore}`
-        : '--';
-
-    return (
-      <Box
-        key={attempt.attemptNumber}
-        sx={{
-          display: 'flex',
-          flexDirection: { xs: 'column', sm: 'row' },
-          alignItems: { xs: 'flex-start', sm: 'center' },
-          justifyContent: 'space-between',
-          gap: 1.5,
-          py: 2.25,
-          px: { xs: 2, md: 2.5 },
+          borderRadius: 5,
+          px: 1.5,
+          py: 0.75,
+          flexWrap: 'wrap',
         }}
       >
-        <Stack
-          direction="row"
-          spacing={1.25}
-          alignItems="center"
-          flexWrap="wrap"
-          rowGap={0.5}
+        <StatusIcon sx={{ fontSize: '14px' }} />
+        <Typography
+          variant="body2"
+          sx={{ fontWeight: 700, whiteSpace: 'nowrap', fontSize: '11px' }}
         >
-          <Typography
-            variant="body2"
-            sx={{ fontWeight: 700, color: theme.palette.text.primary, whiteSpace: 'nowrap' }}
-          >
-            {t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.ATTEMPT_LABEL')}{' '}
-            {attempt.attemptNumber}
-          </Typography>
-
-          {attempt.isAttempted &&
-            renderBadge('completed', t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.COMPLETED'))}
-          {!attempt.isAttempted &&
-            attempt.isLocked &&
-            renderBadge('locked', t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.LOCKED'))}
-          {!attempt.isAttempted &&
-            !attempt.isLocked &&
-            renderBadge(
-              'notAttempted',
-              t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.NOT_ATTEMPTED')
-            )}
-
-          {attempt.isAttempted && attempt.date && (
-            <Typography variant="caption" sx={{ color: theme.palette.text.secondary }}>
-              {attempt.date}
-            </Typography>
-          )}
-
-          {attempt.isAttempted && (attempt.isBestScore || attempt.isLatest) && (
-            <Stack direction="row" spacing={0.75} flexWrap="wrap" rowGap={0.5}>
-              {attempt.isBestScore &&
-                renderBadge('bestScore', t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.BEST_SCORE'))}
-              {attempt.isLatest &&
-                renderBadge('latest', t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.LATEST'))}
-            </Stack>
-          )}
-        </Stack>
-
-        <Stack direction="row" spacing={2} alignItems="center" sx={{ flexShrink: 0 }}>
-          <Typography
-            variant="body1"
-            sx={{
-              fontWeight: 700,
-              minWidth: '48px',
-              whiteSpace: 'nowrap',
-              textAlign: 'right',
-              color: attempt.isAttempted
-                ? customColors.assessmentScoreText
-                : customColors.assessmentNotAttemptedText,
-            }}
-          >
-            {scoreDisplay}
-          </Typography>
-
-          {isNextAttempt && <AttemptAssessmentButton />}
-          {!isNextAttempt && attempt.isLocked && (
+          {t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.ATTEMPT_LABEL')}{' '}
+          {attempt.attemptNumber}
+        </Typography>
+        <Box
+          sx={{
+            width: 4,
+            height: 4,
+            borderRadius: '50%',
+            bgcolor: 'currentColor',
+            opacity: 0.6,
+            flexShrink: 0,
+          }}
+        />
+        <Typography
+          variant="body2"
+          sx={{ fontWeight: 500, whiteSpace: 'nowrap', fontSize: '11px' }}
+        >
+          {statusLabel}
+        </Typography>
+        {attempt.isAttempted &&
+          attempt.score !== null &&
+          attempt.totalMaxScore !== null && (
             <Typography
-              variant="caption"
-              sx={{ color: customColors.assessmentNotAttemptedText, whiteSpace: 'nowrap' }}
+              variant="body2"
+              sx={{ fontWeight: 700, whiteSpace: 'nowrap', fontSize: '11px' }}
             >
-              {t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.AFTER_ATTEMPT_PREFIX')}{' '}
-              {attempt.attemptNumber - 1}
+              {attempt.score}/{attempt.totalMaxScore}
             </Typography>
           )}
-        </Stack>
-      </Box>
+        {attempt.isAttempted &&
+          attempt.attemptNumber === trophyAttemptNumber && (
+            <EmojiEventsOutlinedIcon
+              sx={{
+                fontSize: '16px',
+                color: style.text,
+              }}
+            />
+          )}
+      </Stack>
     );
   };
+
+  const hasNextAttempt =
+    !isBatchAssigned && completedCount < attemptCards.length;
+
+  // Batch-assigned learners only ever see the attempts they've actually
+  // completed — no locked/not-attempted chips, since those slots are moot
+  // once a batch decides the learner's path forward.
+  const visibleAttempts = isBatchAssigned
+    ? attemptCards.filter((attempt) => attempt.isAttempted)
+    : attemptCards;
 
   return (
-    <Box sx={containerSx}>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          flexWrap: 'wrap',
-          gap: 1,
-          px: { xs: 2, md: 2.5 },
-          py: 1.5,
-        }}
-      >
-        <Typography variant="subtitle1" sx={{ fontWeight: 700, fontSize: '16px' }}>
-          {t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.TITLE')}
-        </Typography>
-        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-          {completedCount} {t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.OF')}{' '}
-          {attemptCards.length}{' '}
-          {t('LEARNER_APP.COURSE.ASSESSMENT_ATTEMPTS.COMPLETED_LOWERCASE')}
-        </Typography>
-      </Box>
-      <Divider sx={{ borderColor: customColors.assessmentRowDivider }} />
-      <Box
-        sx={{
-          flex: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'space-around',
-        }}
-      >
-        {attemptCards.map((attempt, index) => (
-          <React.Fragment key={attempt.attemptNumber}>
-            {index > 0 && <Divider sx={{ borderColor: customColors.assessmentRowDivider }} />}
-            {renderAttemptRow(attempt, index)}
-          </React.Fragment>
-        ))}
-      </Box>
-    </Box>
+    <Accordion
+      expanded={isOpen}
+      onChange={(_event, expanded) => setIsOpen(expanded)}
+      disableGutters
+      elevation={0}
+      sx={accordionSx}
+    >
+      {summary}
+      <AccordionDetails sx={{ px: { xs: 2, md: 2.5 }, pt: 0, pb: { xs: 2, md: 2.5 } }}>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          alignItems={{ xs: 'flex-start', sm: 'center' }}
+          justifyContent="space-between"
+          flexWrap="wrap"
+          gap={1.25}
+        >
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            alignItems={{ xs: 'flex-start', sm: 'center' }}
+            flexWrap="wrap"
+            gap={1}
+          >
+            {visibleAttempts.map((attempt) => renderAttemptPill(attempt))}
+          </Stack>
+
+          {hasNextAttempt && <AttemptAssessmentButton />}
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
   );
 };
 

--- a/apps/learner-web-app/src/components/Content/CommonL1ContentList.tsx
+++ b/apps/learner-web-app/src/components/Content/CommonL1ContentList.tsx
@@ -41,6 +41,7 @@ const MyComponent: React.FC<CommonL1ContentListProps> = ({ notab = false }) => {
   const [isLogin, setIsLogin] = useState<boolean | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isProfileCard, setIsProfileCard] = useState(false);
+  const [showAssessmentAttempts, setShowAssessmentAttempts] = useState(true);
   const storedConfig =
     typeof window !== 'undefined'
       ? JSON.parse(localStorage.getItem('uiConfig') || '{}')
@@ -126,9 +127,19 @@ const MyComponent: React.FC<CommonL1ContentListProps> = ({ notab = false }) => {
                 container
                 spacing={2}
                 alignItems="stretch"
-                sx={{ mb: 0, p: { xs: 2, md: 4 } }}
+                sx={{
+                  mb: 0,
+                  px: { xs: 2, md: 4 },
+                  pt: { xs: 2, md: 3 },
+                  pb: { xs: 1, md: 1.5 },
+                }}
               >
-                <Grid item xs={12} md={5} sx={{ display: 'flex' }}>
+                <Grid
+                  item
+                  xs={12}
+                  lg={showAssessmentAttempts ? 6 : 12}
+                  sx={{ display: 'flex' }}
+                >
                   <RegistrationSuccessCard
                     programName={TenantName.SECOND_CHANCE_PROGRAM.replace(
                       ' Program',
@@ -137,9 +148,20 @@ const MyComponent: React.FC<CommonL1ContentListProps> = ({ notab = false }) => {
                     statusLabel={t('LEARNER_APP.COURSE.REGISTERED')}
                   />
                 </Grid>
-                <Grid item xs={12} md={7} sx={{ display: 'flex' }}>
-                  {!notab && <AssessmentAttempts />}
-                </Grid>
+                {!notab && (
+                  <Grid
+                    item
+                    xs={12}
+                    lg={6}
+                    sx={{
+                      display: showAssessmentAttempts ? 'flex' : 'none',
+                    }}
+                  >
+                    <AssessmentAttempts
+                      onVisibilityChange={setShowAssessmentAttempts}
+                    />
+                  </Grid>
+                )}
               </Grid>
             )}
           {!notab && (
@@ -149,14 +171,10 @@ const MyComponent: React.FC<CommonL1ContentListProps> = ({ notab = false }) => {
                 flexDirection: { xs: 'column', sm: 'row' },
                 alignItems: { xs: 'flex-start', sm: 'center' },
                 justifyContent: 'space-between',
-                py: 2,
-                px: { xs: 2, md: 2.5 },
-                bgcolor: '#fff',
-                border: '1px solid',
-                borderColor: (theme) =>
-                  theme.palette.customColors.welcomeBannerBorder,
-                borderRadius: 3,
-                mb: 3,
+
+                mx: { xs: 2, md: 4 },
+
+                mb: 2,
                 gap: 1,
               }}
             >
@@ -167,6 +185,7 @@ const MyComponent: React.FC<CommonL1ContentListProps> = ({ notab = false }) => {
                   fontWeight: 600,
                   color: '#1F1B13',
                   textTransform: 'capitalize',
+                  fontSize: '14px',
                   mb: 0,
                 }}
               >
@@ -175,7 +194,10 @@ const MyComponent: React.FC<CommonL1ContentListProps> = ({ notab = false }) => {
                 </span>
                 {t('COMMON.WELCOME')}, {localStorage.getItem('firstName')}!
               </Typography>
-              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+              <Typography
+                variant="body2"
+                sx={{ color: 'text.secondary', fontSize: '12px' }}
+              >
                 {t('LEARNER_APP.COURSE.COURSE_WELCOME_SUBTITLE')}
               </Typography>
             </Box>

--- a/apps/learner-web-app/src/components/RegistrationSuccessCard/RegistrationSuccessCard.tsx
+++ b/apps/learner-web-app/src/components/RegistrationSuccessCard/RegistrationSuccessCard.tsx
@@ -1,8 +1,19 @@
 import React from 'react';
-import { Box, Button, Divider, Stack, Typography, useTheme } from '@mui/material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Stack,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import InfoIcon from '@mui/icons-material/Info';
 import GetAppIcon from '@mui/icons-material/GetApp';
 import { useTranslation } from '@shared-lib';
+import { useSharedAccordionState } from '@learner/utils/hooks/useSharedAccordionState';
 
 interface RegistrationSuccessCardProps {
   programName: string;
@@ -19,104 +30,123 @@ const RegistrationSuccessCard: React.FC<RegistrationSuccessCardProps> = ({
   const { t } = useTranslation();
   const theme = useTheme();
   const { customColors } = theme.palette;
+  const [isOpen, setIsOpen] = useSharedAccordionState();
 
-  return (
+  const downloadAppText = t('LEARNER_APP.COURSE.PLAYSTORE_DOWNLOAD_MESSAGE').split(
+    '{playStoreLink}'
+  )[0];
+
+  const icon = (
     <Box
       sx={{
+        width: 22,
+        height: 22,
+        borderRadius: '50%',
+        bgcolor: customColors.registrationCardIconBg,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+      }}
+    >
+      <InfoIcon sx={{ fontSize: '14px', color: '#FFFFFF' }} />
+    </Box>
+  );
+
+  const description = (
+    <Typography
+      variant="body2"
+      sx={{ color: theme.palette.text.secondary, fontSize: '12px' }}
+    >
+      {t('LEARNER_APP.COURSE.SECOND_CHANCE_REGISTRATION_MESSAGE')}{' '}
+      {downloadAppText}
+    </Typography>
+  );
+
+  const playStoreButton = (
+    <Button
+      href={PLAY_STORE_LINK}
+      target="_blank"
+      rel="noopener noreferrer"
+      variant="contained"
+      color="primary"
+      startIcon={<GetAppIcon sx={{ fontSize: '18px' }} />}
+      sx={{
+        minWidth: { xs: 'auto', sm: '120px' },
+        fontWeight: 500,
+        fontSize: '12px',
+        lineHeight: '20px',
+        letterSpacing: '0.1px',
+        whiteSpace: 'nowrap',
+        px: { xs: 2, sm: 3 },
+        py: 1,
+        m: '0 !important',
+        boxShadow: '0px 3px 5px rgba(0, 0, 0, 0.2)',
+        flexShrink: 0,
+      }}
+    >
+      {t('LEARNER_APP.COURSE.PLAY_STORE')}
+    </Button>
+  );
+
+  return (
+    <Accordion
+      expanded={isOpen}
+      onChange={(_event, expanded) => setIsOpen(expanded)}
+      disableGutters
+      elevation={0}
+      sx={{
         bgcolor: customColors.registrationCardBackground,
-        borderRadius: 3,
-        p: { xs: 1.5, md: 2 },
+        borderRadius: '12px !important',
         width: '100%',
         flexGrow: 1,
         boxSizing: 'border-box',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
         boxShadow:
           '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1)',
+        '&:before': { display: 'none' },
       }}
     >
-      <Stack direction="row" spacing={1} alignItems="flex-start">
-        <Box
-          sx={{
-            width: 22,
-            height: 22,
-            borderRadius: '50%',
-            bgcolor: customColors.registrationCardIconBg,
-            display: 'flex',
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        sx={{
+          px: { xs: 1.5, md: 2 },
+          minHeight: 'auto',
+          '& .MuiAccordionSummary-content': {
+            my: 1,
             alignItems: 'center',
-            justifyContent: 'center',
-            flexShrink: 0,
-            mt: '2px',
-          }}
-        >
-          <InfoIcon sx={{ fontSize: '14px', color: '#FFFFFF' }} />
-        </Box>
-        <Box sx={{ flex: 1, minWidth: 0 }}>
+          },
+        }}
+      >
+        <Stack direction="row" alignItems="center" gap={1}>
+          {icon}
           <Typography
             variant="subtitle1"
-            sx={{ fontWeight: 700, color: theme.palette.text.primary, fontSize: '16px' }}
+            sx={{ fontWeight: 700, color: theme.palette.text.primary, fontSize: '14px' }}
           >
             {t('LEARNER_APP.COURSE.REGISTRATION_SUCCESSFUL_TITLE')}
           </Typography>
-          <Typography
-            variant="body2"
-            sx={{ color: theme.palette.text.secondary, mt: 0.25 }}
-          >
-            {t('LEARNER_APP.COURSE.SECOND_CHANCE_REGISTRATION_MESSAGE')}
-          </Typography>
+        </Stack>
+      </AccordionSummary>
+
+      <AccordionDetails sx={{ px: { xs: 1.5, md: 2 }, pt: 0, pb: { xs: 1.5, md: 2 } }}>
+        {/* Mobile layout: description, then button below */}
+        <Box sx={{ display: { xs: 'block', sm: 'none' } }}>
+          <Box sx={{ mb: 1.25 }}>{description}</Box>
+          {playStoreButton}
         </Box>
-      </Stack>
 
-      <Divider sx={{ my: 1, borderColor: customColors.registrationDivider }} />
-
-      <Stack
-        direction="row"
-        alignItems="center"
-        justifyContent="space-between"
-        flexWrap="wrap"
-        gap={1.25}
-        rowGap={1}
-      >
-        <Typography variant="body2" sx={{ color: theme.palette.text.secondary }}>
-          {t('LEARNER_APP.COURSE.PLAYSTORE_DOWNLOAD_MESSAGE').split(
-            '{playStoreLink}'
-          )[0]}
-        </Typography>
-
-        <Button
-          href={PLAY_STORE_LINK}
-          target="_blank"
-          rel="noopener noreferrer"
-          variant="outlined"
-          startIcon={<GetAppIcon sx={{ fontSize: '18px' }} />}
-          size="small"
-          disableRipple
-          disableElevation
-          sx={{
-            bgcolor: '#FFFFFF',
-            color: theme.palette.secondary.main,
-            borderColor: customColors.registrationDivider,
-            boxShadow: 'none',
-            fontWeight: 600,
-            fontSize: '13px',
-            textTransform: 'none',
-            borderRadius: 5,
-            m: '0 !important',
-            px: 2.25,
-            py: 0.75,
-            flexShrink: 0,
-            '&:hover': {
-              bgcolor: '#FFFFFF',
-              borderColor: customColors.registrationDivider,
-              boxShadow: 'none',
-            },
-          }}
+        {/* Desktop layout: description + button, single row */}
+        <Stack
+          direction="row"
+          alignItems="center"
+          gap={1.5}
+          sx={{ display: { xs: 'none', sm: 'flex' } }}
         >
-          {t('LEARNER_APP.COURSE.PLAY_STORE')}
-        </Button>
-      </Stack>
-    </Box>
+          <Box sx={{ flex: 1, minWidth: 0 }}>{description}</Box>
+          {playStoreButton}
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
   );
 };
 

--- a/apps/learner-web-app/src/utils/helpers/assessmentAttemptHelpers.ts
+++ b/apps/learner-web-app/src/utils/helpers/assessmentAttemptHelpers.ts
@@ -11,7 +11,6 @@ export interface AssessmentAttemptCardData {
   date: string | null;
   isBestScore: boolean;
   isLatest: boolean;
-  isLocked: boolean;
 }
 
 const getAttemptDateValue = (attempt: AssessmentRecord): number => {
@@ -122,7 +121,6 @@ export const mapAttemptCards = (
         date: null,
         isBestScore: false,
         isLatest: false,
-        isLocked: index > 0 && !sortedAttempts[index - 1],
       };
     }
 
@@ -135,7 +133,6 @@ export const mapAttemptCards = (
       date: formatAttemptDate(attempt.lastAttemptedOn || attempt.createdOn),
       isBestScore: canShowBestScore && !!bestAttempt && attempt === bestAttempt,
       isLatest: !!latestAttempt && attempt === latestAttempt,
-      isLocked: false,
     };
   });
 };

--- a/apps/learner-web-app/src/utils/helpers/cohortAssignmentHelper.ts
+++ b/apps/learner-web-app/src/utils/helpers/cohortAssignmentHelper.ts
@@ -1,0 +1,68 @@
+import { getAcademicYear } from '@learner/utils/API/AcademicYearService';
+import { getCohortList } from '@learner/utils/API/CohortService';
+
+interface CohortRecord {
+  type?: string;
+  cohortStatus?: string;
+  cohortMemberStatus?: string;
+}
+
+interface AcademicYearRecord {
+  id?: string;
+  isActive?: boolean;
+}
+
+// Module-scoped cache so the batch-assignment API check runs once per full
+// page load/reload, not on every client-side route change within the SPA.
+// A full reload re-executes this module and clears the cache; a route change
+// (which keeps the module alive) reuses the in-flight/resolved promise.
+let cachedCheck: { userId: string; promise: Promise<boolean> } | null = null;
+
+export const checkUserHasActiveBatch = (userId: string): Promise<boolean> => {
+  if (cachedCheck?.userId === userId) {
+    return cachedCheck.promise;
+  }
+
+  const promise = fetchUserHasActiveBatch(userId);
+  cachedCheck = { userId, promise };
+  return promise;
+};
+
+const fetchUserHasActiveBatch = async (userId: string): Promise<boolean> => {
+  const previousAcademicYearId = localStorage.getItem('academicYearId');
+
+  try {
+    const academicYearList = await getAcademicYear();
+    const allAcademicYearIds = Array.isArray(academicYearList)
+      ? academicYearList
+          .map((year: AcademicYearRecord) => year?.id)
+          .filter(Boolean)
+      : [];
+
+    for (const yearId of allAcademicYearIds) {
+      localStorage.setItem('academicYearId', yearId as string);
+      const cohortResponse = await getCohortList(userId, true, true);
+      const hasBatch = Array.isArray(cohortResponse?.result)
+        ? cohortResponse.result.some(
+            (cohort: CohortRecord) =>
+              cohort?.type === 'BATCH' && cohort?.cohortStatus === 'active'
+          )
+        : false;
+
+      if (hasBatch) {
+        return true;
+      }
+    }
+
+    return false;
+  } catch (error) {
+    console.error('checkUserHasActiveBatch: failed to verify batch assignment', error);
+    return false;
+  } finally {
+    if (previousAcademicYearId) {
+      localStorage.setItem('academicYearId', previousAcademicYearId);
+    } else {
+      localStorage.removeItem('academicYearId');
+    }
+  }
+};

--- a/apps/learner-web-app/src/utils/hooks/useSharedAccordionState.ts
+++ b/apps/learner-web-app/src/utils/hooks/useSharedAccordionState.ts
@@ -1,0 +1,42 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+const STORAGE_KEY = 'topCardsAccordionOpen';
+
+// Not included in preserveLocalStorage()'s keep-list (src/utils/helper.ts), so
+// logout's localStorage.clear() wipes this key — the next login naturally
+// starts fresh (defaultOpen) without any explicit reset wiring.
+const listeners = new Set<() => void>();
+
+const readStoredValue = (): boolean => {
+  if (typeof window === 'undefined') return true;
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return stored === null ? true : stored === 'true';
+};
+
+let cachedValue = readStoredValue();
+
+const subscribe = (onStoreChange: () => void) => {
+  listeners.add(onStoreChange);
+  return () => listeners.delete(onStoreChange);
+};
+
+const getSnapshot = () => cachedValue;
+const getServerSnapshot = () => true;
+
+const setSharedAccordionOpen = (value: boolean) => {
+  cachedValue = value;
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, String(value));
+  }
+  listeners.forEach((listener) => listener());
+};
+
+export const useSharedAccordionState = (): [boolean, (value: boolean) => void] => {
+  const isOpen = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const setIsOpen = useCallback((value: boolean) => {
+    setSharedAccordionOpen(value);
+  }, []);
+
+  return [isOpen, setIsOpen];
+};


### PR DESCRIPTION
- PS-7258 : SCP Dashboard - need to manage space and width of top newly introduced sections
- PS-7257 : SCP Dashboard - change Play Store button color yellow
- PS-7256 : SCP learner dashboard = Don't show the Attempt section if the batch is assigned without an attempt Saral test