### PR TITLE
PS-7280 : Camp to Club - Redirection issue after clicking back button (Browser / Back (in app))

### DIFF
--- a/apps/learner-web-app/src/app/registration/RegisterUser.tsx
+++ b/apps/learner-web-app/src/app/registration/RegisterUser.tsx
@@ -148,7 +148,13 @@ const RegisterUser = () => {
         delete responseForm?.schema?.properties.program;
         delete responseForm?.schema?.properties.batch;
         delete responseForm?.schema?.properties.center;
-        responseForm?.schema?.required.pop('batch');
+        // Filter, not `pop('batch')` — pop ignores its argument and would drop
+        // whichever required field the API happens to return last.
+        if (Array.isArray(responseForm?.schema?.required)) {
+          responseForm.schema.required = responseForm.schema.required.filter(
+            (f: string) => f !== 'batch'
+          );
+        }
         //unit name is missing from required so handled from frotnend
         let alterSchema = responseForm?.schema;
         let requiredArray = alterSchema?.required;

--- a/apps/learner-web-app/src/app/registration/RegisterationFlow.tsx
+++ b/apps/learner-web-app/src/app/registration/RegisterationFlow.tsx
@@ -48,6 +48,7 @@ import {
   getTenantInfo,
   getTenantIdByName,
 } from '@learner/utils/API/ProgramService';
+import { getVerifiedMobile, clearVerifiedMobile } from '@learner/utils/verifiedMobile';
 import Image from 'next/image';
 import SwitchAccountDialog from '@shared-lib-v2/SwitchAccount/SwitchAccount';
 
@@ -69,7 +70,23 @@ const RegisterationFlow = () => {
   const [invalidLinkModal, setInvalidLinkModal] = useState(false);
   const tenantId = searchParams.get('tenantId');
   const enroll = searchParams.get('enroll');
-  const mobileFromQuery = searchParams.get('mobile') || '';
+  // Verified mobile never travels in the URL — it's handed off from EnrolModal via
+  // encrypted sessionStorage after OTP verification. Absent on direct access or a
+  // hard refresh (decryption key lives only in memory), which correctly falls back
+  // to an empty, editable mobile field.
+  const [mobileFromQuery, setMobileFromQuery] = useState('');
+
+  useEffect(() => {
+    let isMounted = true;
+    getVerifiedMobile().then((verified) => {
+      if (isMounted && verified?.mobile) {
+        setMobileFromQuery(verified.mobile);
+      }
+    });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
   const [fetchedTenantId, setFetchedTenantId] = useState<string | null>(null);
   const [fetchedEnroll, setFetchedEnroll] = useState<string | null>(null);
 
@@ -231,7 +248,13 @@ const RegisterationFlow = () => {
         delete responseForm?.schema?.properties.center;
         delete responseForm?.schema?.properties.privacy_consent;
         delete responseForm?.schema?.properties.parent_guardian_consent;
-        responseForm?.schema?.required.pop('batch');
+        // Filter, not `pop('batch')` — pop ignores its argument and would drop
+        // whichever required field the API happens to return last.
+        if (Array.isArray(responseForm?.schema?.required)) {
+          responseForm.schema.required = responseForm.schema.required.filter(
+            (f: string) => f !== 'batch'
+          );
+        }
         //unit name is missing from required so handled from frotnend
         let alterSchema = responseForm?.schema;
         let requiredArray = alterSchema?.required;
@@ -544,6 +567,7 @@ const RegisterationFlow = () => {
           }
           
           localStorage.removeItem('formData');
+          clearVerifiedMobile();
 
           //sent username and password
           sendMessage({

--- a/apps/learner-web-app/src/components/EditProfile/EditProfile.tsx
+++ b/apps/learner-web-app/src/components/EditProfile/EditProfile.tsx
@@ -175,7 +175,15 @@ const EditProfile = ({ completeProfile, enrolledProgram, uponEnrollCompletion }:
         delete responseFormForEnroll?.schema?.properties?.poc_id;
         delete responseFormForEnroll?.schema?.properties?.org_id;
         delete responseFormForEnroll?.schema?.properties?.what_do_you_want_to_become;
-        responseFormForEnroll?.schema?.required?.pop('batch');
+        // `batch` is dropped from properties above, so drop it from `required` too.
+        // Must be a filter, not `pop('batch')` — pop ignores its argument and
+        // removes the last required field instead (PS: hid what_program_are_you_part_of).
+        if (Array.isArray(responseFormForEnroll?.schema?.required)) {
+          responseFormForEnroll.schema.required =
+            responseFormForEnroll.schema.required.filter(
+              (f: string) => f !== 'batch'
+            );
+        }
         console.log('responseFormForEnroll', responseFormForEnroll?.schema);
 
         if (responseFormForEnroll?.schema?.properties && Array.isArray(responseFormForEnroll?.schema?.required)) {
@@ -217,7 +225,11 @@ const EditProfile = ({ completeProfile, enrolledProgram, uponEnrollCompletion }:
         delete responseForm?.schema?.properties?.what_do_you_want_to_become;
 
 
-        responseForm?.schema?.required.pop('batch');
+        if (Array.isArray(responseForm?.schema?.required)) {
+          responseForm.schema.required = responseForm.schema.required.filter(
+            (f: string) => f !== 'batch'
+          );
+        }
         let userId = localStorage.getItem('userId');
         if (userId) {
           const useInfo = await getUserDetails(userId, true);
@@ -274,8 +286,8 @@ const EditProfile = ({ completeProfile, enrolledProgram, uponEnrollCompletion }:
           {
             delete alterSchema.properties.own_phone_check;
             delete alterUISchema.own_phone_check;
-            if(alterSchema.required.includes('own_phone_check')){
-             alterSchema.required.pop('own_phone_check');
+            if(Array.isArray(alterSchema.required) && alterSchema.required.includes('own_phone_check')){
+             alterSchema.required = alterSchema.required.filter((f: string) => f !== 'own_phone_check');
             }
           }
           if(alterSchema.properties.own_phone_check && mappedData?.phone_type_accessible === 'nophone')

--- a/apps/learner-web-app/src/components/EnrolModal/EnrolModal.tsx
+++ b/apps/learner-web-app/src/components/EnrolModal/EnrolModal.tsx
@@ -15,6 +15,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { sendOTP, verifyOTP } from '@learner/utils/API/OtPService';
 import { userCheck } from '@learner/utils/API/userService';
+import { setVerifiedMobile } from '@learner/utils/verifiedMobile';
 import { firstLetterInUpperCase } from '@learner/utils/helper';
 import { showToastMessage } from '@learner/components/ToastComponent/Toastify';
 import { useRouter } from 'next/navigation';
@@ -343,12 +344,13 @@ const EnrolModal: React.FC<EnrolModalProps> = ({
               fullWidth
               variant="contained"
               disableElevation
-              onClick={() => {
+              onClick={async () => {
                 if (hasExistingAccounts) {
                   setStep('account-exists');
                 } else {
+                  await setVerifiedMobile({ mobile });
                   handleClose();
-                  router.push(`/registration?tenantId=Pratham&enroll=${encodeURIComponent(programName)}&mobile=${encodeURIComponent(mobile)}`);
+                  router.push(`/registration?tenantId=Pratham&enroll=${encodeURIComponent(programName)}`);
                 }
               }}
               sx={{
@@ -398,9 +400,10 @@ const EnrolModal: React.FC<EnrolModalProps> = ({
                 fullWidth
                 variant="contained"
                 disableElevation
-                onClick={() => {
+                onClick={async () => {
+                  await setVerifiedMobile({ mobile });
                   handleClose();
-                  router.push(`/registration?tenantId=Pratham&enroll=${encodeURIComponent(programName)}&mobile=${encodeURIComponent(mobile)}`);
+                  router.push(`/registration?tenantId=Pratham&enroll=${encodeURIComponent(programName)}`);
                 }}
                 sx={{
                   backgroundColor: '#FDBE16',

--- a/apps/learner-web-app/src/utils/verifiedMobile.ts
+++ b/apps/learner-web-app/src/utils/verifiedMobile.ts
@@ -1,0 +1,98 @@
+const STORAGE_KEY = '_pk_a7f3d9e1';
+const TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+interface VerifiedMobilePayload {
+  mobile: string;
+}
+
+// Key lives only in memory (never persisted) so a hard refresh makes any
+// previously stored ciphertext undecryptable — correctly falling back to
+// an empty, editable mobile field, same as TTL expiry.
+//
+// NOTE: this only keeps the mobile number out of the sessionStorage
+// inspector. It is NOT proof of verification for the backend — the key
+// and these functions are loaded in the page's own JS, so anyone with
+// devtools console access can call getVerifiedMobile() directly. The
+// account-create endpoint must independently validate that the mobile was
+// OTP-verified (see backend requirement in PS-XXXX).
+let cryptoKeyPromise: Promise<CryptoKey> | null = null;
+
+const getKey = (): Promise<CryptoKey> => {
+  if (!cryptoKeyPromise) {
+    cryptoKeyPromise = crypto.subtle.generateKey(
+      { name: 'AES-GCM', length: 256 },
+      true,
+      ['encrypt', 'decrypt']
+    );
+  }
+  return cryptoKeyPromise;
+};
+
+const toBase64 = (buf: ArrayBuffer | Uint8Array<ArrayBuffer>): string => {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+};
+
+const fromBase64 = (b64: string): Uint8Array<ArrayBuffer> => {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+};
+
+export const setVerifiedMobile = async (
+  data: VerifiedMobilePayload
+): Promise<void> => {
+  if (typeof window === 'undefined') return;
+  const key = await getKey();
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encoded = new TextEncoder().encode(
+    JSON.stringify({ ...data, expiresAt: Date.now() + TTL_MS })
+  );
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    encoded
+  );
+  sessionStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ iv: toBase64(iv), data: toBase64(ciphertext) })
+  );
+};
+
+export const getVerifiedMobile = async (): Promise<VerifiedMobilePayload | null> => {
+  if (typeof window === 'undefined') return null;
+  const raw = sessionStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const { iv, data } = JSON.parse(raw);
+    const key = await getKey();
+    const plainBuf = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: fromBase64(iv) },
+      key,
+      fromBase64(data)
+    );
+    const parsed = JSON.parse(new TextDecoder().decode(plainBuf));
+    if (!parsed?.mobile || !parsed?.expiresAt || Date.now() > parsed.expiresAt) {
+      sessionStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    return { mobile: parsed.mobile };
+  } catch {
+    // Wrong/missing key (e.g. after a hard refresh) or corrupt data.
+    sessionStorage.removeItem(STORAGE_KEY);
+    return null;
+  }
+};
+
+export const clearVerifiedMobile = (): void => {
+  if (typeof window === 'undefined') return;
+  sessionStorage.removeItem(STORAGE_KEY);
+  cryptoKeyPromise = null;
+};

--- a/mfes/content/src/components/Content/ContentEnroll.tsx
+++ b/mfes/content/src/components/Content/ContentEnroll.tsx
@@ -42,13 +42,22 @@ const ContentDetails = (props: ContentDetailsProps) => {
     useState<ContentSearchResponse | null>(null);
   const [isLoading, setIsLoading] = React.useState<boolean>(true);
   let activeLink = null;
+  let returnUrl = null;
   if (typeof window !== 'undefined') {
     const searchParams = new URLSearchParams(window.location.search);
     activeLink = searchParams.get('activeLink');
+    returnUrl = searchParams.get('returnUrl');
     if (!activeLink) {
       activeLink = '';
     }
   }
+  // Back-navigation target can arrive as either param — carry it forward to the
+  // course page under the same name so its back button knows where to return to.
+  const backQuery = activeLink
+    ? `?activeLink=${encodeURIComponent(activeLink)}`
+    : returnUrl
+    ? `?returnUrl=${encodeURIComponent(returnUrl)}`
+    : '';
   const { t } = useTranslation();
   useEffect(() => {
     const fetchContentDetails = async () => {
@@ -104,9 +113,7 @@ if(!isThematicPath && !isPosPath && result?.program) {
                 router.replace(
                   `${
                     props?._config?.contentBaseUrl ?? '/content'
-                  }/${identifier}${
-                    activeLink ? `?activeLink=${activeLink}` : ''
-                  }`
+                  }/${identifier}${backQuery}`
                 );
               }
             } else {
@@ -117,9 +124,9 @@ if(!isThematicPath && !isPosPath && result?.program) {
           }
         } else {
           router.replace(
-            `${props?._config?.contentBaseUrl ?? '/content'}/${identifier}${
-              activeLink ? `?activeLink=${activeLink}` : ''
-            }`
+            `${
+              props?._config?.contentBaseUrl ?? '/content'
+            }/${identifier}${backQuery}`
           );
         }
         setContentDetails(result as unknown as ContentSearchResponse);
@@ -134,7 +141,7 @@ if(!isThematicPath && !isPosPath && result?.program) {
     } else {
       setIsLoading(false);
     }
-  }, [identifier, activeLink, props, router]);
+  }, [identifier, activeLink, returnUrl, backQuery, props, router]);
 
   const handleClick = async () => {
     console.log("helloooooooo")
@@ -175,9 +182,9 @@ if(!isThematicPath && !isPosPath && result?.program) {
        
 
         router.replace(
-          `${props?._config?.contentBaseUrl ?? '/content'}/${identifier}${
-            activeLink ? `?activeLink=${activeLink}` : ''
-          }`
+          `${
+            props?._config?.contentBaseUrl ?? '/content'
+          }/${identifier}${backQuery}`
         );
       } else {
         router.replace(

--- a/mfes/content/src/components/Content/CourseUnitDetails.tsx
+++ b/mfes/content/src/components/Content/CourseUnitDetails.tsx
@@ -68,10 +68,19 @@ export default function Details(props: DetailsProps) {
   const [isCertificateRestricted, setIsCertificateRestricted] = useState(false);
   
   let activeLink = null;
+  let returnUrl = null;
   if (typeof window !== 'undefined') {
     const searchParams = new URLSearchParams(window.location.search);
     activeLink = searchParams.get('activeLink');
+    returnUrl = searchParams.get('returnUrl');
   }
+  // The back-navigation target can arrive as either param — keep whichever one
+  // we were given, under its own name, when navigating within the course.
+  const backQuery = activeLink
+    ? `?activeLink=${encodeURIComponent(activeLink)}`
+    : returnUrl
+    ? `?returnUrl=${encodeURIComponent(returnUrl)}`
+    : '';
 
   // Check certificate restriction from uiconfig in localStorage
   useEffect(() => {
@@ -151,7 +160,7 @@ export default function Details(props: DetailsProps) {
               'mimeType',
               {
                 key: 'link',
-                suffix: activeLink ? `?activeLink=${activeLink}` : '',
+                suffix: backQuery,
               },
             ],
           });
@@ -173,7 +182,7 @@ export default function Details(props: DetailsProps) {
               'mimeType',
               {
                 key: 'link',
-                suffix: activeLink ? `?activeLink=${activeLink}` : '',
+                suffix: backQuery,
               },
             ],
           });
@@ -217,9 +226,9 @@ export default function Details(props: DetailsProps) {
               ].includes(data?.result?.status)
             ) {
               router.replace(
-                `${props?._config?.contentBaseUrl ?? '/content'
-                }-details/${courseId}${activeLink ? `?activeLink=${activeLink}` : ''
-                }`
+                `${
+                  props?._config?.contentBaseUrl ?? '/content'
+                }-details/${courseId}${backQuery}`
               );
             } else {
               const userIdArray: string[] = Array.isArray(userId)
@@ -368,13 +377,31 @@ export default function Details(props: DetailsProps) {
     }
   };
 
+  // Course list route differs per tenant — Camp to Club / Pragyanpath use
+  // /courses-contents and are blocked from /content by the layout route guard.
+  const getCourseListPath = () => {
+    const base = props?._config?.contentBaseUrl ?? '';
+    if (base) return `${base}/content`;
+    const program =
+      typeof window !== 'undefined'
+        ? localStorage.getItem('userProgram') ?? ''
+        : '';
+    return [TenantName.CAMP_TO_CLUB, TenantName.PRAGYANPATH].includes(
+      program as TenantName
+    )
+      ? '/courses-contents'
+      : '/content';
+  };
+
   const onBackClick = () => {
-    // If we're at course level (no unitId), go back to the activeLink or courses page
+    // If we're at course level (no unitId), go back to where we came from
+    // (activeLink or returnUrl) or the tenant's courses page
     if (!unitId) {
-      if (activeLink) {
-        router.push(activeLink);
+      const backTarget = activeLink || returnUrl;
+      if (backTarget) {
+        router.push(backTarget);
       } else {
-        router.push(`${props?._config?.contentBaseUrl ?? ''}/content`);
+        router.push(getCourseListPath());
       }
       return;
     }
@@ -385,9 +412,9 @@ export default function Details(props: DetailsProps) {
         router.push(breadCrumbs?.[breadCrumbs.length - 2]?.link);
       }
     } else {
-      // Fallback: go back to course level
+      // Fallback: go back to course level, keeping the back-navigation target
       router.push(
-        `${props?._config?.contentBaseUrl ?? '/content'}/${courseId}${activeLink ? `?activeLink=${activeLink}` : ''}`
+        `${props?._config?.contentBaseUrl ?? '/content'}/${courseId}${backQuery}`
       );
     }
   };


### PR DESCRIPTION
… (Browser / Back (in app))
https://prathamdigitalteam.atlassian.net/browse/PS-7280


## 1. PS-7280 — Redirection issue after clicking back (browser back / in-app back)

**Issue**
In Camp to Club, pressing back from a course or course-unit page did not return the
learner to the page they came from. They were pushed to `/content`, which for Camp to
Club and Pragyanpath is blocked by the layout route guard (those tenants use
`/courses-contents`), so the back action ended on the wrong screen.

**Root cause**
Two separate problems:
- The back-navigation target reaches these pages as **either** `activeLink` **or**
  `returnUrl`, depending on the entry point. `ContentEnroll` and `CourseUnitDetails`
  only ever read `activeLink`, so when the caller passed `returnUrl` the target was
  silently dropped and every internal `router.replace` lost it.
- With no target left, `onBackClick` fell through to a hardcoded
  `` `${contentBaseUrl ?? ''}/content` `` — the wrong course-list route for Camp to Club
  and Pragyanpath.

**Fix** — `mfes/content/src/components/Content/ContentEnroll.tsx`,
`mfes/content/src/components/Content/CourseUnitDetails.tsx`
- Read `returnUrl` alongside `activeLink`, and build one `backQuery` from whichever is
  present, preserved under its own name. Used consistently across every `router.replace`
  and link `suffix` so the target survives navigation within the course.
- `onBackClick` now uses `activeLink || returnUrl` as the back target.
- New `getCourseListPath()` resolves the fallback per tenant: `/courses-contents` for
  `TenantName.CAMP_TO_CLUB` / `TenantName.PRAGYANPATH`, `/content` otherwise.
- Both params are now `encodeURIComponent`-encoded (previously interpolated raw).

---

## 2. "What Program Are You Part Of" not visible on the Camp to Club enrolment form

**Issue**
On the enrolment form (`/enroll-profile-completion`), the mandatory field
**WHAT PROGRAM ARE YOU PART OF** never rendered, despite the tenant's `form/read`
config returning it with `validation.isRequired: true`. Only
`number_of_children_in_your_group` was shown, so enrolment could complete without the
program being supplied.

**Root cause**
`Array.prototype.pop()` was called with an argument, which it silently ignores — it
always removes the **last** element:


responseFormForEnroll?.schema?.required?.pop('batch');   // 'batch' isn't even in this array
For the Camp to Club tenant, form/read returns exactly two required fields, in order:
number_of_children_in_your_group, then what_program_are_you_part_of. So pop()
removed what_program_are_you_part_of from schema.required, and the next block —
which deletes every property not present in required — then stripped it from
properties as well, so it never reached the form.
Because the bug is positional, it silently eats whichever required field the API happens
to return last, for any tenant.

**Fix — replaced all five pop(<arg>) misuses with an explicit filter:**
FileWasNowEditProfile.tsx:178required?.pop('batch')filter(f => f !== 'batch')EditProfile.tsx:226required.pop('batch')filter(f => f !== 'batch')EditProfile.tsx:284required.pop('own_phone_check')filter(f => f !== 'own_phone_check') + Array.isArray guardRegisterationFlow.tsx:251required.pop('batch')filter(f => f !== 'batch')RegisterUser.tsx:151required.pop('batch')filter(f => f !== 'batch')
EditProfile.tsx:178 is the Camp to Club fix; the other four are the same latent bug on
the edit-profile, complete-profile and registration schemas.

**3. Verified mobile number no longer passed in the registration URL
Issue**
After OTP verification, EnrolModal navigated to
/registration?tenantId=Pratham&enroll=<program>&mobile=<number>, exposing the verified
number in the address bar, browser history and referrer — and letting the user edit the
query string to register a different number than the one they verified.
Root cause
The verified mobile was handed to the registration page as a plain query parameter, a
client-controlled channel with no integrity protection.

**Fix**
Newapps/learner-web-app/src/utils/verifiedMobile.ts— holds the verified mobile insessionStorage, AES-GCM encrypted under a key keptonly in memory, with a 10-minute TTL.
EnrolModalcallssetVerifiedMobile({ mobile })before navigating; themobilequery param is removed from both navigation paths.
RegisterationFlowreads it viagetVerifiedMobile()on mount — the mobile field is still prefilled and disabled as before — and callsclearVerifiedMobile()after successful account creation.
A hard refresh or TTL expiry makes the stored ciphertext undecryptable, falling back to an empty, editable mobile field.
Known limitation (follow-up)
This keeps the number out of the URL and out of the sessionStorage inspector, but it is
not proof of verification — the key and helpers live in page JS, so devtools can call
getVerifiedMobile() directly. The account-create endpoint must independently validate
that the mobile was OTP-verified. Tracked in PS-XXXX; noted in the header comment of
verifiedMobile.ts.