### PR TITLE
PS-7272 : LMP = Learner list - on search activity automatically cursor out from the search box

### DIFF
--- a/mfes/scp-teacher-repo/src/components/CohortLearnerList.tsx
+++ b/mfes/scp-teacher-repo/src/components/CohortLearnerList.tsx
@@ -291,18 +291,17 @@ const CohortLearnerList: React.FC<CohortLearnerListProp> = ({
 
   return (
     <div>
+      {userData?.length || searchTerm ? (
+        <SearchBar
+          onSearch={handleSearch}
+          value={searchTerm}
+          placeholder={t('COMMON.SEARCH_STUDENT')}
+        />
+      ) : null}
       {loading ? (
         <Loader showBackdrop={true} loadingText={t('COMMON.LOADING')} />
       ) : (
         <>
-          {userData?.length || searchTerm ? (
-            <SearchBar
-              onSearch={handleSearch}
-              value={searchTerm}
-              placeholder={t('COMMON.SEARCH_STUDENT')}
-            />
-          ) : null}
-
           <Box
             sx={{
               '@media (min-width: 900px)': {


### PR DESCRIPTION
**The bug is in** [CohortLearnerList.tsx](vscode-webview://147opgi0rh77f0icu2cjo514oa8cm719q2crlv4iic9okfbq5ksh/mfes/scp-teacher-repo/src/components/CohortLearnerList.tsx#L292-L304): the whole render swaps between <Loader> and the content (including <SearchBar>) based on loading. Since loading is set to true on every search-triggered fetch (via the useEffect watching searchTerm), the SearchBar — and its input DOM node — gets unmounted and a fresh one remounted each time a search request runs. That's exactly why the input loses focus when the user stops typing (debounce fires → fetch starts → loading → unmount) and even mid-backspacing (a stale debounced call from a few keystrokes ago still fires later and re-triggers the same unmount).

**Fix:** keep SearchBar mounted outside the loading conditional, so only the list/grid area swaps for the loader.

**Fix:** moved <SearchBar> outside the loading ternary so it stays mounted continuously; only the list/grid area now swaps for the Loader. Typing state and focus are preserved through the fetch cycle.
