### PR TITLE
CMS - Disable content review/publish/reject email notifications

### DIFF
--- a/mfes/editors/src/components/CollectionEditor.tsx
+++ b/mfes/editors/src/components/CollectionEditor.tsx
@@ -803,17 +803,19 @@ const CollectionEditor: React.FC = () => {
             if (event.detail?.action === 'submitContent') {
               console.log('collection');
 
-              sendReviewNotification({
-                contentId: identifier,
-                creator: getLocalStoredUserName(),
-              })
-                .then(() => {
-                  window.history.back();
-                })
-                .catch((error) => {
-                  console.error('Error in sendReviewNotification:', error);
-                });
-            } 
+              // Disabled: was emailing every CCTA reviewer matching this content's board/subject ("onContentReview") when content was submitted for review
+              // sendReviewNotification({
+              //   contentId: identifier,
+              //   creator: getLocalStoredUserName(),
+              // })
+              //   .then(() => {
+              //     window.history.back();
+              //   })
+              //   .catch((error) => {
+              //     console.error('Error in sendReviewNotification:', error);
+              //   });
+              window.history.back();
+            }
             else if( event.detail?.action === "publishContent")
               
             {

--- a/mfes/editors/src/components/GenericEditor.tsx
+++ b/mfes/editors/src/components/GenericEditor.tsx
@@ -190,10 +190,11 @@ const GenericEditor: React.FC = () => {
                     console.log("Review Event triggered inside iframe!", event);
                     console.log("window", window);
                     console.log("window parent", window?.parent);
-                    sendReviewNotification({
-                      contentId: window?.parent?.context?.contentId,
-                      creator: getLocalStoredUserName(),
-                    });
+                    // Disabled: was emailing every CCTA reviewer matching this content's board/subject ("onContentReview") when content was submitted for review
+                    // sendReviewNotification({
+                    //   contentId: window?.parent?.context?.contentId,
+                    //   creator: getLocalStoredUserName(),
+                    // });
                   }
                 );
               }

--- a/mfes/editors/src/components/QuestionSetEditor.tsx
+++ b/mfes/editors/src/components/QuestionSetEditor.tsx
@@ -264,16 +264,18 @@ const QuestionSetEditor: React.FC<{
             if (event.detail?.action === "submitContent") {
               console.log("collection");
 
-              sendReviewNotification({
-                contentId: identifier,
-                creator: getLocalStoredUserName(),
-              })
-                .then(() => {
-                  window.history.back();
-                })
-                .catch((error) => {
-                  console.error("Error in sendReviewNotification:", error);
-                });
+              // Disabled: was emailing every CCTA reviewer matching this content's board/subject ("onContentReview") when content was submitted for review
+              // sendReviewNotification({
+              //   contentId: identifier,
+              //   creator: getLocalStoredUserName(),
+              // })
+              //   .then(() => {
+              //     window.history.back();
+              //   })
+              //   .catch((error) => {
+              //     console.error("Error in sendReviewNotification:", error);
+              //   });
+              window.history.back();
             } else if (event.detail?.action === "publishContent") {
               console.log("Publishing content");
               setIsPublishing(true);

--- a/mfes/editors/src/services/sendContentNotification.ts
+++ b/mfes/editors/src/services/sendContentNotification.ts
@@ -53,13 +53,14 @@ export const sendContentNotification = async (
         replacements["{reviwerComment}"] = editorType === Editor.CONTENT ? comment : contentDetails?.rejectComment;
       }
   
-      await sendCredentialService({
-        isQueue,
-        context,
-        key,
-        replacements,
-        email: { receipients: [response?.userData?.email] },
-      });
+      // Disabled: was emailing the content creator ("onContentPublish"/"onContentReject") when a reviewer published or rejected their submission
+      // await sendCredentialService({
+      //   isQueue,
+      //   context,
+      //   key,
+      //   replacements,
+      //   email: { receipients: [response?.userData?.email] },
+      // });
   
       const previousPage = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('previousPage') : null;
       if (previousPage && previousPage.startsWith('/')) {

--- a/mfes/workspace/src/services/sendContentNotification.ts
+++ b/mfes/workspace/src/services/sendContentNotification.ts
@@ -52,13 +52,14 @@ export const sendContentNotification = async (
         replacements["{reviwerComment}"] = editorType === Editor.CONTENT ? comment : contentDetails?.rejectComment;
       }
   
-      await sendCredentialService({
-        isQueue,
-        context,
-        key,
-        replacements,
-        email: { receipients: [response?.userData?.email] },
-      });
+      // Disabled: was emailing the content creator ("onContentPublish"/"onContentReject") when a reviewer published or rejected their submission
+      // await sendCredentialService({
+      //   isQueue,
+      //   context,
+      //   key,
+      //   replacements,
+      //   email: { receipients: [response?.userData?.email] },
+      // });
   
       const previousPage = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('previousPage') : null;
       if (previousPage && previousPage.startsWith('/')) {


### PR DESCRIPTION
**Changes**
1. **Reviewer notification on submit (onContentReview)** — disabled the call to sendReviewNotification(...), which emailed every active CCTA reviewer matching the content's board/subject, in:

- mfes/editors/src/components/GenericEditor.tsx
- mfes/editors/src/components/QuestionSetEditor.tsx
- mfes/editors/src/components/CollectionEditor.tsx

2. **Creator notification on publish/reject (onContentPublish / onContentReject)** — disabled the sendCredentialService(...) call inside sendContentNotification(), which emailed the original content creator when a reviewer published or rejected their submission, in:

- mfes/editors/src/services/sendContentNotification.ts
- mfes/workspace/src/services/sendContentNotification.ts

All disabled calls are commented out (not deleted) with a one-line comment describing what each one used to send, so they can be re-enabled easily later.

**Why**
Stop outbound content-review emails without touching the review/publish/reject workflow itself.

**What's NOT affected**

1. Content status transitions (submit → review → publish/reject) — handled by the editor web components / iframe internals or the onEvent callback, none of which were touched.
2. Navigation after submit/publish/reject (window.history.back(), router.push(...) to the up-review/draft list) — preserved explicitly.
3. UI refresh after publish/reject (setFetchContentAPI toggle in CollectionEditor) — untouched.

**Known no-op left in place**
sendContentNotification() still calls getUserDetailsInfo() to look up the creator's email even though the email is no longer sent — a harmless extra network call, left in so the diff stays minimal. Can be cleaned up in a follow-up if desired.

**Testing**

-  Submit content for review → confirm no reviewer email is sent, content still transitions to "in review" and navigates back correctly.
-  Publish reviewed content → confirm no creator email is sent, content list refreshes and reviewer is redirected as before.
-  Reject reviewed content → confirm no creator email is sent, same navigation/refresh behavior as before.
- Let me know if you want this trimmed down or want the ticket number worked into a specific section.
- 
